### PR TITLE
feat: use docker to deploy fpm

### DIFF
--- a/.github/workflows/package-apisix-openresty.yml
+++ b/.github/workflows/package-apisix-openresty.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: build apisix-openresty rpm
         run: |
-          make package type=rpm app=apisix-openresty version=${BUILD_APISIX_OR_VERSION}
+          make package type=rpm app=apisix-openresty version=${BUILD_APISIX_OR_VERSION} checkout=${BUILD_APISIX_OR_VERSION}
 
       - name: run centos7 docker and mapping apisix-openresty rpm into container
         run: |

--- a/.github/workflows/package-apisix-openresty.yml
+++ b/.github/workflows/package-apisix-openresty.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: build apisix-openresty rpm
         run: |
-          make package type=rpm app=apisix-openresty version=${BUILD_APISIX_OR_VERSION} checkout=${BUILD_APISIX_OR_VERSION}
+          make package type=rpm app=apisix-openresty version=${BUILD_APISIX_OR_VERSION}
 
       - name: run centos7 docker and mapping apisix-openresty rpm into container
         run: |

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ build-apisix-rpm:
 .PHONY: package-apisix-rpm
 package-apisix-rpm:
 	docker build -t apache/apisix-packaged:$(version) \
-	--build-arg VERSION=$(version) \
-	--build-arg ITERATION=$(iteration) \
-	--build-arg PACKAGE_VERSION=$(version) \
-	-f ./dockerfiles/Dockerfile.package.apisix .
-	docker run -d --name output --net="host" apache/apisix-packaged:$(version)
+		--build-arg VERSION=$(version) \
+		--build-arg ITERATION=$(iteration) \
+		--build-arg PACKAGE_VERSION=$(version) \
+		-f ./dockerfiles/Dockerfile.package.apisix .
+	docker run -d --rm --name output --net="host" apache/apisix-packaged:$(version)
 	docker cp output:/output ${PWD}
 	docker stop output
 	docker system prune -a -f
@@ -54,11 +54,11 @@ build-dashboard-rpm:
 .PHONY: package-dashboard-rpm
 package-dashboard-rpm:
 	docker build -t apache/apisix-dashboard-packaged:$(version) \
-	--build-arg VERSION=$(version) \
-	--build-arg ITERATION=$(iteration) \
-	--build-arg PACKAGE_VERSION=$(version) \
-	-f ./dockerfiles/Dockerfile.package.apisix-dashboard .
-	docker run -d --name output --net="host" apache/apisix-dashboard-packaged:$(version)
+		--build-arg VERSION=$(version) \
+		--build-arg ITERATION=$(iteration) \
+		--build-arg PACKAGE_VERSION=$(version) \
+		-f ./dockerfiles/Dockerfile.package.apisix-dashboard .
+	docker run -d --rm --name output --net="host" apache/apisix-dashboard-packaged:$(version)
 	docker cp output:/output ${PWD}/output
 	docker stop output
 	docker system prune -a -f
@@ -73,11 +73,11 @@ build-apisix-openresty-rpm:
 .PHONY: package-apisix-openresty-rpm
 package-apisix-openresty-rpm:
 	docker build -t apache/apisix-openresty-packaged:$(version) \
-	--build-arg VERSION=$(version) \
-	--build-arg ITERATION=$(iteration) \
-	--build-arg PACKAGE_VERSION=$(version) \
-	-f ./dockerfiles/Dockerfile.package.apisix-openresty .
-	docker run -d --name output --net="host" apache/apisix-openresty-packaged:$(version)
+		--build-arg VERSION=$(version) \
+		--build-arg ITERATION=$(iteration) \
+		--build-arg PACKAGE_VERSION=$(version) \
+		-f ./dockerfiles/Dockerfile.package.apisix-openresty .
+	docker run -d --rm --name output --net="host" apache/apisix-openresty-packaged:$(version)
 	docker cp output:/output ${PWD}
 	docker stop output
 	docker system prune -a -f

--- a/Makefile
+++ b/Makefile
@@ -28,88 +28,65 @@ iteration=0
 ### build apisix:
 .PHONY: build-apisix-rpm
 build-apisix-rpm:
-	mkdir -p ${PWD}/build/rpm
-	docker build -t apache/apisix:$(version) --build-arg checkout_v=$(checkout) -f ./dockerfiles/Dockerfile.apisix.rpm .
-	docker run -d --name dockerInstance --net="host" apache/apisix:$(version)
-	docker cp dockerInstance:/tmp/build/output/ ${PWD}/build/rpm
-	docker system prune -a -f
+	docker build -t apache/apisix:$(version) --build-arg checkout_v=$(checkout) \
+		-f ./dockerfiles/Dockerfile.apisix.rpm .
 
 ### build rpm for apisix:
 .PHONY: package-apisix-rpm
 package-apisix-rpm:
-	fpm -f -s dir -t rpm \
-		-n apisix \
-		-a `uname -i` \
-		-v $(version) \
-		--iteration $(iteration) \
-		-d 'openresty >= 1.17.8.2' \
-		--description 'Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.' \
-		--license "ASL 2.0" \
-		-C ${PWD}/build/rpm/output/apisix/ \
-		-p ${PWD}/output/ \
-		--url 'http://apisix.apache.org/' \
-		--config-files usr/lib/systemd/system/apisix.service
-	rm -rf ${PWD}/build
+	docker build -t apache/apisix-packaged:$(version) \
+	--build-arg VERSION=$(version) \
+	--build-arg ITERATION=$(iteration) \
+	--build-arg PACKAGE_VERSION=$(version) \
+	-f ./dockerfiles/Dockerfile.package.apisix .
+	docker run -d --name output --net="host" apache/apisix-packaged:$(version)
+	docker cp output:/output ${PWD}
+	docker stop output
+	docker system prune -a -f
 
 ### build dashboard:
 .PHONY: build-dashboard-rpm
 build-dashboard-rpm:
-	mkdir -p ${PWD}/build/rpm
-	docker build -t apache/apisix-dashboard:$(version) --build-arg checkout_v=$(checkout) -f ./dockerfiles/Dockerfile.dashboard.rpm .
-	docker run -d --name dockerInstance --net="host" apache/apisix-dashboard:$(version)
-	docker cp dockerInstance:/tmp/build/output/ ${PWD}/build/rpm
-	docker system prune -a -f
+	docker build -t apache/apisix-dashboard:$(version) --build-arg checkout_v=$(checkout) \
+		-f ./dockerfiles/Dockerfile.dashboard.rpm .
 
 ### build rpm for apisix dashboard:
 .PHONY: package-dashboard-rpm
 package-dashboard-rpm:
-	fpm -f -s dir -t rpm \
-		-n apisix-dashboard \
-		-a `uname -i` \
-		-v $(version) \
-		--iteration $(iteration) \
-		--description 'Apache APISIX Dashboard is designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.'  \
-		--license "ASL 2.0" \
-		-C ${PWD}/build/rpm/output/apisix/dashboard/ \
-		-p ${PWD}/output/ \
-		--url 'https://github.com/apache/apisix-dashboard'
-
-	rm -rf ${PWD}/build
+	docker build -t apache/apisix-dashboard-packaged:$(version) \
+	--build-arg VERSION=$(version) \
+	--build-arg ITERATION=$(iteration) \
+	--build-arg PACKAGE_VERSION=$(version) \
+	-f ./dockerfiles/Dockerfile.package.apisix-dashboard .
+	docker run -d --name output --net="host" apache/apisix-dashboard-packaged:$(version)
+	docker cp output:/output ${PWD}/output
+	docker stop output
+	docker system prune -a -f
 
 ### build apisix-openresty:
 .PHONY: build-apisix-openresty-rpm
 build-apisix-openresty-rpm:
-	mkdir -p ${PWD}/build/rpm
 	docker build -t apache/apisix-openresty:$(version) --build-arg version=$(version) \
 		-f ./dockerfiles/Dockerfile.apisix-openresty.rpm .
-	docker run -d --name dockerInstance --net="host" apache/apisix-openresty:$(version)
-	docker cp dockerInstance:/usr/local/openresty/ ${PWD}/build/rpm
-	docker system prune -a -f
 
 ### build rpm for apisix-openresty:
 .PHONY: package-apisix-openresty-rpm
 package-apisix-openresty-rpm:
-	fpm -f -s dir -t rpm \
-		-n apisix-openresty \
-		-a `uname -i` \
-		-v $(version) \
-		--iteration $(iteration) \
-		-x openresty/zlib \
-		-x openresty/openssl111 \
-		-x openresty/pcre \
-		-d 'openresty-zlib >= 1.2.11-3' \
-		-d 'openresty-openssl111 >= 1.1.1h-1' \
-		-d 'openresty-pcre >= 8.44-1' \
-		--post-install ${PWD}/post-install-apisix-openresty.sh \
-		--description "APISIX's OpenResty distribution." \
-		--license "ASL 2.0" \
-		-C ${PWD}/build/rpm \
-		-p ${PWD}/output/ \
-		--url 'http://apisix.apache.org/' \
-		--conflicts openresty \
-		--config-files usr/lib/systemd/system/openresty.service \
-		--prefix=/usr/local
-	rm -rf ${PWD}/build
+	docker build -t apache/apisix-openresty-packaged:$(version) \
+	--build-arg VERSION=$(version) \
+	--build-arg ITERATION=$(iteration) \
+	--build-arg PACKAGE_VERSION=$(version) \
+	-f ./dockerfiles/Dockerfile.package.apisix-openresty .
+	docker run -d --name output --net="host" apache/apisix-openresty-packaged:$(version)
+	docker cp output:/output ${PWD}
+	docker stop output
+	docker system prune -a -f
+
+
+### build fpm for packaging:
+.PHONY: build-fpm
+build-fpm:
+	docker build -t api7/fpm - < ./dockerfiles/Dockerfile.fpm
 
 ifeq ($(filter $(app),apisix dashboard apisix-openresty),)
 $(info  the app's value have to be apisix or dashboard!)
@@ -121,6 +98,7 @@ else ifeq ($(version), 0)
 $(info  you have to input a version value!)
 
 else ifeq ($(app)_$(type),apisix-openresty_rpm)
+package: build-fpm
 package: build-apisix-openresty-rpm
 package: package-apisix-openresty-rpm
 
@@ -128,10 +106,12 @@ else ifeq ($(checkout), 0)
 $(info  you have to input a checkout value!)
 
 else ifeq ($(app)_$(type),apisix_rpm)
+package: build-fpm
 package: build-apisix-rpm
 package: package-apisix-rpm
 
 else ifeq ($(app)_$(type),dashboard_rpm)
+package: build-fpm
 package: build-dashboard-rpm
 package: package-dashboard-rpm
 

--- a/dockerfiles/Dockerfile.apisix.rpm
+++ b/dockerfiles/Dockerfile.apisix.rpm
@@ -1,6 +1,6 @@
 ARG image_base="centos"
 ARG image_tag="7"
-ARG checkout_v="2.2"
+ARG checkout_v="2.6"
 ARG iteration="0"
 ARG apisix_repo="https://github.com/apache/apisix"
 

--- a/dockerfiles/Dockerfile.apisix.rpm
+++ b/dockerfiles/Dockerfile.apisix.rpm
@@ -1,8 +1,8 @@
 ARG image_base="centos"
 ARG image_tag="7"
-ARG checkout_v="2.6"
 ARG iteration="0"
 ARG apisix_repo="https://github.com/apache/apisix"
+ARG checkout_v
 
 FROM ${image_base}:${image_tag}
 

--- a/dockerfiles/Dockerfile.dashboard.rpm
+++ b/dockerfiles/Dockerfile.dashboard.rpm
@@ -10,7 +10,7 @@ RUN set -x \
     # install dependency
     && yum install -y wget curl git which gcc make \
     && curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo \
-    && sh -c "$(curl -fsSL https://rpm.nodesource.com/setup_10.x)" \
+    && sh -c "$(curl -fsSL https://rpm.nodesource.com/setup_14.x)" \
     && yum install -y nodejs yarn \
     && wget https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz \
     && tar -xzf go1.15.2.linux-amd64.tar.gz \

--- a/dockerfiles/Dockerfile.fpm
+++ b/dockerfiles/Dockerfile.fpm
@@ -1,0 +1,9 @@
+FROM ubuntu:focal
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y git \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ruby ruby-dev rubygems build-essential rpm \
+    && gem install fpm \
+    && fpm --version
+
+CMD /usr/local/bin/fpm

--- a/dockerfiles/Dockerfile.package.apisix
+++ b/dockerfiles/Dockerfile.package.apisix
@@ -1,0 +1,16 @@
+ARG VERSION
+
+FROM apache/apisix:${VERSION} AS APISIX
+FROM api7/fpm
+
+ARG ITERATION
+ARG PACKAGE_VERSION
+
+ENV ITERATION=${ITERATION}
+ENV PACKAGE_VERSION=${PACKAGE_VERSION}
+
+COPY --from=APISIX /tmp/build/output /tmp/build/output
+COPY package-apisix.sh /package-apisix.sh
+COPY usr /usr
+
+RUN /package-apisix.sh

--- a/dockerfiles/Dockerfile.package.apisix-dashboard
+++ b/dockerfiles/Dockerfile.package.apisix-dashboard
@@ -1,0 +1,15 @@
+ARG VERSION
+
+FROM apache/apisix-dashboard:${VERSION} AS APISIX
+FROM api7/fpm
+
+ARG ITERATION
+ARG PACKAGE_VERSION
+
+ENV ITERATION=${ITERATION}
+ENV PACKAGE_VERSION=${PACKAGE_VERSION}
+
+COPY --from=APISIX /tmp/build/output /tmp/build/output
+COPY package-apisix-dashboard.sh /package-apisix-dashboard.sh
+
+RUN /package-apisix-dashboard.sh

--- a/dockerfiles/Dockerfile.package.apisix-openresty
+++ b/dockerfiles/Dockerfile.package.apisix-openresty
@@ -1,0 +1,17 @@
+ARG VERSION
+
+FROM apache/apisix-openresty:${VERSION} AS APISIX
+FROM api7/fpm
+
+ARG ITERATION
+ARG PACKAGE_VERSION
+
+ENV ITERATION=${ITERATION}
+ENV PACKAGE_VERSION=${PACKAGE_VERSION}
+
+COPY --from=APISIX /usr/local/openresty /tmp/build/output/openresty
+COPY package-apisix-openresty.sh /package-apisix-openresty.sh
+COPY post-install-apisix-openresty.sh /post-install-apisix-openresty.sh
+COPY usr /usr
+
+RUN /package-apisix-openresty.sh

--- a/package-apisix-dashboard.sh
+++ b/package-apisix-dashboard.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+fpm -f -s dir -t rpm \
+	-n apisix-dashboard \
+	-a "$(uname -i)" \
+	-v "$PACKAGE_VERSION" \
+	--iteration "$ITERATION" \
+	--description 'Apache APISIX Dashboard is designed to make it as easy as possible for users to operate Apache APISIX through a frontend interface.'  \
+	--license "ASL 2.0" \
+	-C /tmp/build/output/apisix/dashboard/ \
+	-p /output \
+	--url 'https://github.com/apache/apisix-dashboard'

--- a/package-apisix-openresty.sh
+++ b/package-apisix-openresty.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+mkdir /output
+fpm -f -s dir -t rpm \
+	-n apisix-openresty \
+	-a "$(uname -i)" \
+	-v "$PACKAGE_VERSION" \
+	--iteration "$ITERATION" \
+	-x openresty/zlib \
+	-x openresty/openssl111 \
+	-x openresty/pcre \
+	-d 'openresty-zlib >= 1.2.11-3' \
+	-d 'openresty-openssl111 >= 1.1.1h-1' \
+	-d 'openresty-pcre >= 8.44-1' \
+	--post-install post-install-apisix-openresty.sh \
+	--description "APISIX's OpenResty distribution." \
+	--license "ASL 2.0" \
+	-C /tmp/build/output \
+	-p /output \
+	--url 'http://apisix.apache.org/' \
+	--conflicts openresty \
+	--config-files usr/lib/systemd/system/openresty.service \
+	--prefix=/usr/local

--- a/package-apisix.sh
+++ b/package-apisix.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+mkdir /output
+fpm -f -s dir -t rpm \
+	-n apisix \
+	-a "$(uname -i)" \
+	-v "$PACKAGE_VERSION" \
+	--iteration "$ITERATION" \
+	-d 'openresty >= 1.17.8.2' \
+	--description 'Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.' \
+	--license "ASL 2.0" \
+	-C /tmp/build/output/apisix \
+	-p /output \
+	--url 'http://apisix.apache.org/' \
+	--config-files usr/lib/systemd/system/apisix.service


### PR DESCRIPTION
Fix: https://github.com/api7/apisix-build-tools/issues/20

What this PR does:
1. Deploy fpm using dockerfile.
2. Package apisix in  docker container and prepare for adding cache later.