### PR TITLE
fix: add pcre

### DIFF
--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -56,6 +56,7 @@ install_openresty_deb() {
 install_openresty_rpm() {
     # install openresty and openssl111
     yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
+    yum install -y pcre-devel
     yum install -y openresty openresty-openssl111-devel
 }
 


### PR DESCRIPTION
APISIX added casbin that requires pcre, so we need to install pcre when packaging.