### PR TITLE
feat: Add pcre and libpcre as package dependencies

### DIFF
--- a/package-apisix.sh
+++ b/package-apisix.sh
@@ -6,11 +6,9 @@ dist=$(cat /tmp/dist)
 
 # Determine the dependencies
 dep_pcre="pcre"
-dep_libpcre="pcre-devel"
 if [ "$PACKAGE_TYPE" == "deb" ]
 then
 	dep_pcre="libpcre3"
-	dep_libpcre="libpcre3-dev"
 fi
 
 fpm -f -s dir -t "$PACKAGE_TYPE" \
@@ -21,7 +19,6 @@ fpm -f -s dir -t "$PACKAGE_TYPE" \
 	--iteration "$ITERATION" \
 	-d 'openresty >= 1.17.8.2' \
 	-d "$dep_pcre" \
-	-d "$dep_libpcre" \
 	--description 'Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.' \
 	--license "ASL 2.0" \
 	-C /tmp/build/output/apisix \

--- a/package-apisix.sh
+++ b/package-apisix.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 set -x
 mkdir /output
 dist=$(cat /tmp/dist)
+
+# Determine the dependencies
+dep_pcre="pcre"
+dep_libpcre="pcre-devel"
+if [ "$PACKAGE_TYPE" == "deb" ]
+then
+	dep_pcre="libpcre3"
+	dep_libpcre="libpcre3-dev"
+fi
+
 fpm -f -s dir -t "$PACKAGE_TYPE" \
 	--"$PACKAGE_TYPE"-dist "$dist" \
 	-n apisix \
@@ -10,6 +20,8 @@ fpm -f -s dir -t "$PACKAGE_TYPE" \
 	-v "$PACKAGE_VERSION" \
 	--iteration "$ITERATION" \
 	-d 'openresty >= 1.17.8.2' \
+	-d "$dep_pcre" \
+	-d "$dep_libpcre" \
 	--description 'Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.' \
 	--license "ASL 2.0" \
 	-C /tmp/build/output/apisix \

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -45,7 +45,7 @@ install_lua() {
 install_openresty_deb() {
     # install openresty and openssl111
     DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3-dev libssl-dev perl build-essential
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libssl-dev perl build-essential
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
     wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
     echo "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/openresty.list
@@ -56,7 +56,7 @@ install_openresty_deb() {
 install_openresty_rpm() {
     # install openresty and openssl111
     yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-openssl111-devel pcre-devel
+    yum install -y openresty openresty-openssl111-devel pcre pcre-devel
 }
 
 install_luarocks() {


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Fixes #72.

This PR is going to add `pcre` and `libpcre` as the dependencies of apisix package, which is required for lua-resty-casbin. The new package names are following the guide of lua-resty-casbin, see https://github.com/casbin-lua/lua-resty-casbin#installation.