### PR TITLE
ci: Using Buildx as Docker builder

### DIFF
--- a/.github/workflows/package-apisix-dashboard-el7-buildx.yml
+++ b/.github/workflows/package-apisix-dashboard-el7-buildx.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build rpm package
         run: |
-          make package type=rpm app=dashboard version=${DASHBOARD_VERSION} checkout=release/${DASHBOARD_VERSION} image_base=centos image_tag=7 buildx=true
+          make package type=rpm app=dashboard version=${DASHBOARD_VERSION} checkout=release/${DASHBOARD_VERSION} image_base=centos image_tag=7 buildx=True
 
       - name: Run centos7 docker and mapping apisix into container
         run: |

--- a/.github/workflows/package-apisix-dashboard-el7-buildx.yml
+++ b/.github/workflows/package-apisix-dashboard-el7-buildx.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Run centos7 docker and mapping apisix into container
         run: |
-          docker run -itd -v $PWD:/apisix-dashboard --name centos7Instance --net="host" docker.io/centos:7 /bin/bash
+          docker run -itd -v $PWD/output:/apisix-dashboard --name centos7Instance --net="host" docker.io/centos:7 /bin/bash
 
       - name: Install rpm package
         run: |

--- a/.github/workflows/package-apisix-dashboard-el7-buildx.yml
+++ b/.github/workflows/package-apisix-dashboard-el7-buildx.yml
@@ -36,6 +36,14 @@ jobs:
 
       - uses: docker/setup-buildx-action@v1
 
+      - uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-apisixdashboard-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-apisixdashboard-
+            ${{ runner.os }}-buildx-
+
       - name: run apisix-dashboard packaging test
         run: |
           make package type=rpm app=dashboard version=${DASHBOARD_VERSION} checkout=release/${DASHBOARD_VERSION} image_base=centos image_tag=7 buildx=True

--- a/.github/workflows/package-apisix-dashboard-el7-buildx.yml
+++ b/.github/workflows/package-apisix-dashboard-el7-buildx.yml
@@ -1,4 +1,4 @@
-name: Auto Build RPM
+name: package apisix-dashabord rpm for el7 using buildx
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  auto_build_rpm:
+  build:
     runs-on: ubuntu-latest
     env:
       DASHBOARD_VERSION: 2.7
@@ -36,11 +36,11 @@ jobs:
 
       - uses: docker/setup-buildx-action@v1
 
-      - name: Build rpm package
+      - name: run apisix-dashboard packaging test
         run: |
           make package type=rpm app=dashboard version=${DASHBOARD_VERSION} checkout=release/${DASHBOARD_VERSION} image_base=centos image_tag=7 buildx=True
 
-      - name: Run centos7 docker and mapping apisix into container
+      - name: Run centos7 docker and mapping rpm into container
         run: |
           docker run -itd -v $PWD/output:/apisix-dashboard --name centos7Instance --net="host" docker.io/centos:7 /bin/bash
 

--- a/.github/workflows/package-apisix-dashboard-el7-buildx.yml
+++ b/.github/workflows/package-apisix-dashboard-el7-buildx.yml
@@ -1,0 +1,59 @@
+name: Auto Build RPM
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  auto_build_rpm:
+    runs-on: ubuntu-latest
+    env:
+      DASHBOARD_VERSION: 2.7
+    services:
+      etcd:
+        image: bitnami/etcd:3.4.0
+        ports:
+          - 2379:2379
+          - 2380:2380
+        env:
+          ALLOW_NONE_AUTHENTICATION: yes
+          ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          sudo apt-get install -y make ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
+          sudo apt-get install -y rpm
+
+      - uses: docker/setup-buildx-action@v1
+
+      - name: Build rpm package
+        run: |
+          make package type=rpm app=dashboard version=${DASHBOARD_VERSION} checkout=release/${DASHBOARD_VERSION} image_base=centos image_tag=7 buildx=true
+
+      - name: Run centos7 docker and mapping apisix into container
+        run: |
+          docker run -itd -v $PWD:/apisix-dashboard --name centos7Instance --net="host" docker.io/centos:7 /bin/bash
+
+      - name: Install rpm package
+        run: |
+          docker exec centos7Instance bash -c "yum install -y /apisix-dashboard/apisix-dashboard-${DASHBOARD_VERSION}-0.el7.x86_64.rpm"
+          docker logs centos7Instance
+          docker exec centos7Instance bash -c "cd /usr/local/apisix/dashboard/ && nohup ./manager-api &"
+
+      - name: Run test cases
+        run: |
+          code=$(curl -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9000)
+          if [ ! $code -eq 200 ]; then
+              echo "failed: failed to install Apache APISIX Dashboard by rpm"
+              exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ define build
 		--build-arg checkout_v=$(checkout) \
 		--build-arg IMAGE_BASE=$(image_base) \
 		--build-arg IMAGE_TAG=$(image_tag) \
+		--build-arg CODE_PATH=$(4) \
 		--load \
 		--cache-from=$(cache_from) \
 		--cache-to=$(cache_to) \

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ cache_to=type=local,dest=/tmp/.buildx-cache
 ### $(2) is dockerfile filename
 ### $(3) is package type
 ### $(4) is code path
-ifneq ($(buildx), "True")
+ifneq ($(buildx), True)
 define build
 	docker build -t apache/$(1)-$(3):$(version) \
 		--build-arg checkout_v=$(checkout) \
@@ -140,7 +140,7 @@ package-apisix-openresty-rpm:
 
 ### build fpm for packaging:
 .PHONY: build-fpm
-ifneq ($(buildx), "True")
+ifneq ($(buildx), True)
 build-fpm:
 	docker build -t api7/fpm - < ./dockerfiles/Dockerfile.fpm
 else

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ cache_to=type=local,dest=/tmp/.buildx-cache
 ### $(2) is dockerfile filename
 ### $(3) is package type
 ### $(4) is code path
-ifeq ($(buildx), 0)
+ifneq ($(buildx), "true")
 define build
 	docker build -t apache/$(1)-$(3):$(version) \
 		--build-arg checkout_v=$(checkout) \
@@ -140,7 +140,7 @@ package-apisix-openresty-rpm:
 
 ### build fpm for packaging:
 .PHONY: build-fpm
-ifeq ($(buildx), 0)
+ifneq ($(buildx), "true")
 build-fpm:
 	docker build -t api7/fpm - < ./dockerfiles/Dockerfile.fpm
 else

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ image_tag="20.04"
 endif
 
 buildx=0
-cache_from="/tmp/.buildx-cache"
-cache_to="/tmp/.buildx-cache"
+cache_from=type=local,src=/tmp/.buildx-cache
+cache_to=type=local,dest=/tmp/.buildx-cache
 ### function for building
 ### $(1) is name
 ### $(2) is dockerfile filename

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ cache_to=type=local,dest=/tmp/.buildx-cache
 ### $(2) is dockerfile filename
 ### $(3) is package type
 ### $(4) is code path
-ifneq ($(buildx), "true")
+ifneq ($(buildx), "True")
 define build
 	docker build -t apache/$(1)-$(3):$(version) \
 		--build-arg checkout_v=$(checkout) \
@@ -140,7 +140,7 @@ package-apisix-openresty-rpm:
 
 ### build fpm for packaging:
 .PHONY: build-fpm
-ifneq ($(buildx), "true")
+ifneq ($(buildx), "True")
 build-fpm:
 	docker build -t api7/fpm - < ./dockerfiles/Dockerfile.fpm
 else

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 |local_code_path  |False | the path of local code diretory of apisix or dashboard, which depends on the app parameter|local_code_path=/home/vagrant/apisix|
 |image_base|False |the environment for packaging, if type is `rpm` the default image_base is `centos`, if type is `deb` the default image_base is `ubuntu`|image_base=centos|
 |image_tag|False |the environment for packaging, it's value can be `16.04\|18.04\|20.04\|6\|7\|8`, if type is `rpm` the default image_tag is `7`, if type is `deb` the default image_tag is `20.04`|image_tag=7|
+|buildx|False|if `true`, use buildx to build docker images, which may speed up GitHub Actions|buildx=true|
 
 ## Example
 Packaging a Centos 7 package of Apache APISIX

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 |local_code_path  |False | the path of local code diretory of apisix or dashboard, which depends on the app parameter|local_code_path=/home/vagrant/apisix|
 |image_base|False |the environment for packaging, if type is `rpm` the default image_base is `centos`, if type is `deb` the default image_base is `ubuntu`|image_base=centos|
 |image_tag|False |the environment for packaging, it's value can be `16.04\|18.04\|20.04\|6\|7\|8`, if type is `rpm` the default image_tag is `7`, if type is `deb` the default image_tag is `20.04`|image_tag=7|
-|buildx|False|if `true`, use buildx to build docker images, which may speed up GitHub Actions|buildx=True|
+|buildx|False|if `True`, use buildx to build docker images, which may speed up GitHub Actions|buildx=True|
 
 ## Example
 Packaging a Centos 7 package of Apache APISIX

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 |local_code_path  |False | the path of local code diretory of apisix or dashboard, which depends on the app parameter|local_code_path=/home/vagrant/apisix|
 |image_base|False |the environment for packaging, if type is `rpm` the default image_base is `centos`, if type is `deb` the default image_base is `ubuntu`|image_base=centos|
 |image_tag|False |the environment for packaging, it's value can be `16.04\|18.04\|20.04\|6\|7\|8`, if type is `rpm` the default image_tag is `7`, if type is `deb` the default image_tag is `20.04`|image_tag=7|
-|buildx|False|if `true`, use buildx to build docker images, which may speed up GitHub Actions|buildx=true|
+|buildx|False|if `true`, use buildx to build docker images, which may speed up GitHub Actions|buildx=True|
 
 ## Example
 Packaging a Centos 7 package of Apache APISIX


### PR DESCRIPTION
When I try to optimize apisix-dashboard's CI, I find that the build script in this repo is a reason for slow CI. As discuss in https://github.com/apache/apisix-dashboard/pull/2072, using buildx can cache Docker layers and so speed up CI.