### PR TITLE
feat: Enable CI for tag v* and prepare for tag v2.0.0

### DIFF
--- a/.github/workflows/package-apisix-dashboard-el7.yml
+++ b/.github/workflows/package-apisix-dashboard-el7.yml
@@ -3,6 +3,8 @@ name: package apisix-dashabord rpm for el7
 on:
   push:
     branches: [ master ]
+    tag:
+      - "v*"
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/package-apisix-dashboard-el7.yml
+++ b/.github/workflows/package-apisix-dashboard-el7.yml
@@ -3,7 +3,7 @@ name: package apisix-dashabord rpm for el7
 on:
   push:
     branches: [ master ]
-    tag:
+    tags:
       - "v*"
   pull_request:
     branches: [ master ]

--- a/.github/workflows/package-apisix-dashboard-el8.yml
+++ b/.github/workflows/package-apisix-dashboard-el8.yml
@@ -3,7 +3,7 @@ name: package apisix-dashabord rpm for el8
 on:
   push:
     branches: [ master ]
-    tag:
+    tags:
       - "v*"
   pull_request:
     branches: [ master ]

--- a/.github/workflows/package-apisix-dashboard-el8.yml
+++ b/.github/workflows/package-apisix-dashboard-el8.yml
@@ -3,6 +3,8 @@ name: package apisix-dashabord rpm for el8
 on:
   push:
     branches: [ master ]
+    tag:
+      - "v*"
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/package-apisix-deb-default.yml
+++ b/.github/workflows/package-apisix-deb-default.yml
@@ -3,7 +3,7 @@ name: package apisix deb for the default image ubuntu 20.04(Focal Fossa)
 on:
   push:
     branches: [ master ]
-    tag:
+    tags:
       - "v*"
   pull_request:
     branches: [ master ]

--- a/.github/workflows/package-apisix-deb-default.yml
+++ b/.github/workflows/package-apisix-deb-default.yml
@@ -3,6 +3,8 @@ name: package apisix deb for the default image ubuntu 20.04(Focal Fossa)
 on:
   push:
     branches: [ master ]
+    tag:
+      - "v*"
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/package-apisix-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-deb-ubuntu20.04.yml
@@ -3,7 +3,7 @@ name: package apisix deb for ubuntu 20.04(Focal Fossa)
 on:
   push:
     branches: [ master ]
-    tag:
+    tags:
       - "v*"
   pull_request:
     branches: [ master ]

--- a/.github/workflows/package-apisix-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-deb-ubuntu20.04.yml
@@ -3,6 +3,8 @@ name: package apisix deb for ubuntu 20.04(Focal Fossa)
 on:
   push:
     branches: [ master ]
+    tag:
+      - "v*"
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/package-apisix-openresty-el7.yml
+++ b/.github/workflows/package-apisix-openresty-el7.yml
@@ -3,7 +3,7 @@ name: package apisix-openresty rpm for el7
 on:
   push:
     branches: [ master ]
-    tag:
+    tags:
       - "v*"
   pull_request:
     branches: [ master ]

--- a/.github/workflows/package-apisix-openresty-el7.yml
+++ b/.github/workflows/package-apisix-openresty-el7.yml
@@ -3,6 +3,8 @@ name: package apisix-openresty rpm for el7
 on:
   push:
     branches: [ master ]
+    tag:
+      - "v*"
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/package-apisix-rpm-el7.yml
+++ b/.github/workflows/package-apisix-rpm-el7.yml
@@ -3,7 +3,7 @@ name: package apisix rpm for el7
 on:
   push:
     branches: [ master ]
-    tag:
+    tags:
       - "v*"
   pull_request:
     branches: [ master ]

--- a/.github/workflows/package-apisix-rpm-el7.yml
+++ b/.github/workflows/package-apisix-rpm-el7.yml
@@ -3,6 +3,8 @@ name: package apisix rpm for el7
 on:
   push:
     branches: [ master ]
+    tag:
+      - "v*"
   pull_request:
     branches: [ master ]
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+
+## Table of Contents
+
+- [2.0.0](#200)
+
+## 2.0.0
+
+This release is the initial release, which is mainly to support building apisix,
+apisix-dashboard and apisix-openrestyboth for rpm and deb artifacts.
+
+
+[Back to TOC](#table-of-contents)


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

This PR is going to do the preparations for the release `v2.0.0`, which contains enabling CI for tags and adding changelog. Right after this PR gets merged, I will push the tag `v2.0.0` from this commit.

Fixes https://github.com/api7/apisix-build-tools/issues/75.