### PR TITLE
feat: Support use local code for packaging

### DIFF
--- a/.github/workflows/package-apisix-dashboard-local-el7.yml
+++ b/.github/workflows/package-apisix-dashboard-local-el7.yml
@@ -1,0 +1,63 @@
+name: package apisix-dashabord(locally) rpm for el7
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - "v*"
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DASHBOARD_VERSION: master
+    services:
+      etcd:
+        image: bitnami/etcd:3.4.0
+        ports:
+          - 2379:2379
+          - 2380:2380
+        env:
+          ALLOW_NONE_AUTHENTICATION: yes
+          ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          sudo apt-get install -y make ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
+          sudo apt-get install -y rpm
+
+      - name: clone apisix
+        run: |
+          git clone -b ${DASHBOARD_VERSION} https://github.com/apache/apisix-dashboard.git
+
+      - name: run apisix-dashboard packaging test
+        run: |
+          make package type=rpm app=dashboard version=${DASHBOARD_VERSION} checkout=${DASHBOARD_VERSION} \
+            image_base=centos image_tag=7 local_code_path=./apisix-dashboard
+
+      - name: Run centos7 docker and mapping rpm into container
+        run: |
+          docker run -itd -v $PWD/output:/apisix-dashboard --name centos7Instance --net="host" docker.io/centos:7 /bin/bash
+
+      - name: Install rpm package
+        run: |
+          docker exec centos7Instance bash -c "yum install -y /apisix-dashboard/apisix-dashboard-${DASHBOARD_VERSION}-0.el7.x86_64.rpm"
+          docker logs centos7Instance
+          docker exec centos7Instance bash -c "cd /usr/local/apisix/dashboard/ && nohup ./manager-api &"
+
+      - name: Run test cases
+        run: |
+          code=$(curl -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9000)
+          if [ ! $code -eq 200 ]; then
+              echo "failed: failed to install Apache APISIX Dashboard by rpm"
+              exit 1
+          fi
+

--- a/.github/workflows/package-apisix-local-deb-default.yml
+++ b/.github/workflows/package-apisix-local-deb-default.yml
@@ -1,0 +1,57 @@
+name: package apisix(locally) deb for the default image ubuntu 20.04(Focal Fossa)
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - "v*"
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_APISIX_VERSION: 2.7
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          sudo apt-get install -y make
+
+      - name: clone apisix
+        run: |
+          git clone -b ${PACKAGE_APISIX_VERSION} https://github.com/apache/apisix.git
+
+      - name: run apisix packaging
+        run: |
+          make package type=deb app=apisix version=${PACKAGE_APISIX_VERSION} checkout=${PACKAGE_APISIX_VERSION} local_code_path=./apisix
+
+      - name: install apisix deb into container
+        run: |
+          docker build -t apache/apisix:${PACKAGE_APISIX_VERSION}-deb-test --build-arg APISIX_VERSION=${PACKAGE_APISIX_VERSION} -f test/apisix/Dockerfile.test.apisix.deb.ubuntu20.04 .
+
+      - name: start apisix and test
+        run: |
+          docker run -d --rm --name apisix-${PACKAGE_APISIX_VERSION}-deb-test -v $(pwd)/test/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9080:9080 -p 9443:9443 apache/apisix:${PACKAGE_APISIX_VERSION}-deb-test
+          sleep 20
+          curl http://127.0.0.1:9080/apisix/admin/routes/1 \
+           -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1' -X PUT -d '
+            {
+              "uri": "/get",
+              "upstream": {
+                  "type": "roundrobin",
+                  "nodes": {
+                      "httpbin.org:80": 1
+                  }
+              }
+            }'
+          result_code=`curl -I -m 10 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/get`
+          if [[ $result_code -ne 200 ]]; then
+              printf "result_code: %s\n" "$result_code"
+              exit 125
+          fi

--- a/.github/workflows/package-apisix-local-rpm-el7.yml
+++ b/.github/workflows/package-apisix-local-rpm-el7.yml
@@ -1,0 +1,63 @@
+name: package apisix(locally) rpm for el7
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - "v*"
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      etcd:
+        image: bitnami/etcd:3.4.0
+        ports:
+          - 2379:2379
+          - 2380:2380
+        env:
+          ALLOW_NONE_AUTHENTICATION: yes
+          ETCD_ADVERTISE_CLIENT_URLS: http://0.0.0.0:2379
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: install dependencies
+        run: |
+          sudo apt-get install -y make ruby ruby-dev rubygems build-essential
+          sudo gem install --no-document fpm
+          sudo apt-get install -y rpm
+
+      - name: clone apisix
+        run: |
+          git clone https://github.com/apache/apisix.git
+
+      - name: packaging APISIX
+        run: |
+          make package type=rpm app=apisix version=master checkout=master image_base=centos image_tag=7 local_code_path=./apisix
+
+      - name: run centos7 docker and mapping rpm into container
+        run: |
+          docker run -itd -v $PWD/output:/output --name centos7Instance --net="host" docker.io/centos:7 /bin/bash
+
+      - name: install dependencies in container
+        run: |
+          docker exec centos7Instance bash -c "yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo"
+          docker exec centos7Instance bash -c "yum -y install openresty openresty-openssl111-devel"
+
+      - name: install APISIX by rpm in container
+        run: |
+          docker exec centos7Instance bash -c "yum -y localinstall /output/apisix-master-0.el7.x86_64.rpm"
+          docker exec centos7Instance bash -c "apisix start"
+
+      - name: check and ensure APISIX is installed
+        run: |
+          code=$(curl -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/admin/routes -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1')
+          if [ ! $code -eq 200 ]; then
+              echo "failed: failed to install Apache APISIX by rpm"
+              exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 |app      |True |it can be `apisix`, `dashboard` or `apisix-openresty`|app=apisix|
 |checkout   |True |the code branch or tag of the app which you want to package|checkout=2.1 or checkout=v2.1|
 |version  |True |the version of the package|version=10.10|
+|local_code_path  |False | the path of local code diretory of apisix or dashboard, which depends on the app parameter|local_code_path=/home/vagrant/apisix|
 |image_base|False |the environment for packaging, if type is `rpm` the default image_base is `centos`, if type is `deb` the default image_base is `ubuntu`|image_base=centos|
 |image_tag|False |the environment for packaging, it's value can be `16.04\|18.04\|20.04\|6\|7\|8`, if type is `rpm` the default image_tag is `7`, if type is `deb` the default image_tag is `20.04`|image_tag=7|
 

--- a/dockerfiles/Dockerfile.apisix.deb
+++ b/dockerfiles/Dockerfile.apisix.deb
@@ -11,6 +11,7 @@ ARG apisix_repo="https://github.com/apache/apisix"
 ARG checkout_v
 ARG IMAGE_BASE
 ARG IMAGE_TAG
+ARG CODE_PATH
 
 # install dependencies
 RUN /install-common.sh install_apisix_dependencies_deb
@@ -20,6 +21,8 @@ ENV iteration=${iteration}
 ENV apisix_repo=${apisix_repo}
 ENV IMAGE_BASE=${IMAGE_BASE}
 ENV IMAGE_TAG=${IMAGE_TAG}
+
+COPY ${CODE_PATH} /apisix
 
 # install apisix
 RUN /install-common.sh install_apisix \

--- a/dockerfiles/Dockerfile.apisix.rpm
+++ b/dockerfiles/Dockerfile.apisix.rpm
@@ -11,6 +11,7 @@ ARG apisix_repo="https://github.com/apache/apisix"
 ARG checkout_v
 ARG IMAGE_BASE
 ARG IMAGE_TAG
+ARG CODE_PATH
 
 # install dependencies
 RUN /install-common.sh install_apisix_dependencies_rpm
@@ -20,6 +21,8 @@ ENV iteration=${iteration}
 ENV apisix_repo=${apisix_repo}
 ENV IMAGE_BASE=${IMAGE_BASE}
 ENV IMAGE_TAG=${IMAGE_TAG}
+
+COPY ${CODE_PATH} /apisix
 
 # install apisix
 RUN /install-common.sh install_apisix \

--- a/dockerfiles/Dockerfile.dashboard.rpm
+++ b/dockerfiles/Dockerfile.dashboard.rpm
@@ -17,12 +17,14 @@ RUN set -x \
 
 ARG checkout_v="v2.3"
 ARG iteration="0"
-ARG dashboard_repo="https://github.com/apache/apisix-dashboard.git"
 ARG IMAGE_BASE
 ARG IMAGE_TAG
+ARG CODE_PATH
 
 ENV IMAGE_BASE=${IMAGE_BASE}
 ENV IMAGE_TAG=${IMAGE_TAG}
+
+COPY ${CODE_PATH} /apisix-dashboard
 
 RUN set -x \
     && mkdir -p /tmp/build/output/apisix/dashboard/usr/bin/ \
@@ -36,10 +38,7 @@ RUN set -x \
     && mkdir gopath \
     && go env -w GOPROXY=https://goproxy.cn,direct \
     && cd /tmp/ \
-    # get source code and build
-    && git clone ${dashboard_repo} \
-    && cd apisix-dashboard \
-    && git checkout ${checkout_v} \
+    && cd /apisix-dashboard \
     && make build \
     # copy the compiled files to the specified directory for packaging
     && cp -r output/* /tmp/build/output/apisix/dashboard/usr/local/apisix/dashboard \

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -81,10 +81,7 @@ install_etcd() {
 
 install_apisix() {
     mkdir -p /tmp/build/output/apisix/usr/bin/
-    # get source code
-    git clone "${apisix_repo}"
-    cd apisix
-    git checkout ${checkout_v}
+    cd /apisix
     # remove useless code for build
     sed -i 's/url.*/url = ".\/apisix",/' rockspec/apisix-master-${iteration}.rockspec
     sed -i 's/branch.*//' rockspec/apisix-master-${iteration}.rockspec


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Fixes #77.

Currently, this build tool will always download the code from Github during the building stage. This PR is going to add support for building from the local code.

The changes mainly contains:

- Add a new parameter `local_code_path` for makefile to specify where the local code locates
- If `local_code_path` is passed, the script  and copy it to `/apisix` or `/apisix-dashboard` in the bulding container
- If `local_code_path` is not passed, the code will be downloaded remotely and copy it to `/apisix` or `/apisix-dashboard` in the bulding container
- The building container will use that code for the proceeding steps
