### PR TITLE
fix: epel-release

### DIFF
--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -17,10 +17,7 @@ install_apisix_dependencies_rpm() {
 install_dependencies_rpm() {
     # install basic dependencies
     yum -y install wget tar gcc automake autoconf libtool make curl git which unzip
-    wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    rpm -ivh epel-release-latest-7.noarch.rpm
-    # Fix failed to get metalink from epel repository
-    yum --disablerepo=epel -y update ca-certificates
+    yum -y install epel-release
     yum install -y yum-utils readline-dev readline-devel
 
     # install lua 5.1 for compatible with openresty 1.17.8.2


### PR DESCRIPTION
Regarding the reason for the CI failure, it seems that the download link for `epel-release` is no longer available, and I think we should use `yum install epel-release` to install epel-release.