### PR TITLE
ci: Fix no setting config files

### DIFF
--- a/package-apisix.sh
+++ b/package-apisix.sh
@@ -41,7 +41,10 @@ fpm -f -s dir -t "$PACKAGE_TYPE" \
 	-C /tmp/build/output/apisix \
 	-p /output \
 	--url 'http://apisix.apache.org/' \
-	--config-files usr/lib/systemd/system/apisix.service
+	--config-files usr/lib/systemd/system/apisix.service \
+	--config-files usr/local/apisix/conf/config.yaml \
+	--config-files usr/local/apisix/conf/config-default.yaml \
+	--config-files usr/local/apisix/conf/debug.yaml
 
 # Rename deb file with adding $DIST section
 if [ "$PACKAGE_TYPE" == "deb" ]

--- a/package-apisix.sh
+++ b/package-apisix.sh
@@ -43,8 +43,7 @@ fpm -f -s dir -t "$PACKAGE_TYPE" \
 	--url 'http://apisix.apache.org/' \
 	--config-files usr/lib/systemd/system/apisix.service \
 	--config-files usr/local/apisix/conf/config.yaml \
-	--config-files usr/local/apisix/conf/config-default.yaml \
-	--config-files usr/local/apisix/conf/debug.yaml
+	--config-files usr/local/apisix/conf/config-default.yaml
 
 # Rename deb file with adding $DIST section
 if [ "$PACKAGE_TYPE" == "deb" ]


### PR DESCRIPTION
The `config.yaml`, `config-default.yaml` and ~~`debug.yaml`~~ should be marked as config files to keep them unchanged when updating rpm/deb. This PR is going to mark the three files as `--config-files` arguments.

The `--config-files` argument is to decorate the files by the rpm directive `%config`. This will rename the original changed configuration files as `*.rpmsave`. See https://docs.fedoraproject.org/ro/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch09s05s03.html for details.

Related to https://github.com/apache/apisix/issues/5066.


Signed-off-by: imjoey <majunjie@apache.org>