### PR TITLE
ci: Upload apisix-openresty/apisix/dashboard artifact

### DIFF
--- a/.github/workflows/package-apisix-dashboard-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-dashboard-deb-ubuntu20.04.yml
@@ -59,4 +59,5 @@ jobs:
         with:
           name: apisix-dashboard_${{ env.DASHBOARD_VERSION }}-0~ubuntu20.04_amd64.deb
           path: output/apisix-dashboard_${{ env.DASHBOARD_VERSION }}-0~ubuntu20.04_amd64.deb
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-dashboard-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-dashboard-deb-ubuntu20.04.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DASHBOARD_VERSION: 2.7
+      DASHBOARD_VERSION: 2.8
     services:
       etcd:
         image: bitnami/etcd:3.4.0
@@ -54,3 +54,9 @@ jobs:
               exit 1
           fi
 
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix-dashboard_${{ env.DASHBOARD_VERSION }}-0~ubuntu20.04_amd64.deb
+          path: output/apisix-dashboard_${{ env.DASHBOARD_VERSION }}-0~ubuntu20.04_amd64.deb
+          if-no-files-found: error

--- a/.github/workflows/package-apisix-dashboard-el7-buildx.yml
+++ b/.github/workflows/package-apisix-dashboard-el7-buildx.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DASHBOARD_VERSION: 2.7
+      DASHBOARD_VERSION: 2.8
     services:
       etcd:
         image: bitnami/etcd:3.4.0

--- a/.github/workflows/package-apisix-dashboard-rpm-el7.yml
+++ b/.github/workflows/package-apisix-dashboard-rpm-el7.yml
@@ -91,4 +91,5 @@ jobs:
         with:
           name: apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el7.x86_64.rpm
           path: output/apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el7.x86_64.rpm
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-dashboard-rpm-el7.yml
+++ b/.github/workflows/package-apisix-dashboard-rpm-el7.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DASHBOARD_VERSION: 2.7
+      DASHBOARD_VERSION: 2.8
     services:
       etcd:
         image: bitnami/etcd:3.4.0
@@ -81,3 +81,14 @@ jobs:
               echo "failed: failed to install Apache APISIX Dashboard by rpm"
               exit 1
           fi
+
+      - name: Rename rpm package
+        run: |
+          mv output/apisix-dashboard-local-${DASHBOARD_VERSION}-0.el7.x86_64.rpm output/apisix-dashboard-${DASHBOARD_VERSION}-0.el7.x86_64.rpm
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el7.x86_64.rpm
+          path: output/apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el7.x86_64.rpm
+          if-no-files-found: error

--- a/.github/workflows/package-apisix-dashboard-rpm-el8.yml
+++ b/.github/workflows/package-apisix-dashboard-rpm-el8.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DASHBOARD_VERSION: 2.7
+      DASHBOARD_VERSION: 2.8
     services:
       etcd:
         image: bitnami/etcd:3.4.0
@@ -56,3 +56,9 @@ jobs:
               exit 1
           fi
 
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el8.x86_64.rpm
+          path: output/apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el8.x86_64.rpm
+          if-no-files-found: error

--- a/.github/workflows/package-apisix-dashboard-rpm-el8.yml
+++ b/.github/workflows/package-apisix-dashboard-rpm-el8.yml
@@ -61,4 +61,5 @@ jobs:
         with:
           name: apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el8.x86_64.rpm
           path: output/apisix-dashboard-${{ env.DASHBOARD_VERSION }}-0.el8.x86_64.rpm
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-deb-ubuntu20.04.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      PACKAGE_APISIX_VERSION: 2.7
+      PACKAGE_APISIX_VERSION: 2.9
 
     steps:
       - uses: actions/checkout@v2
@@ -54,3 +54,10 @@ jobs:
               printf "result_code: %s\n" "$result_code"
               exit 125
           fi
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix_${{ env.PACKAGE_APISIX_VERSION }}-0~ubuntu20.04_amd64.deb
+          path: output/apisix_${{ env.PACKAGE_APISIX_VERSION }}-0~ubuntu20.04_amd64.deb
+          if-no-files-found: error

--- a/.github/workflows/package-apisix-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-deb-ubuntu20.04.yml
@@ -60,4 +60,5 @@ jobs:
         with:
           name: apisix_${{ env.PACKAGE_APISIX_VERSION }}-0~ubuntu20.04_amd64.deb
           path: output/apisix_${{ env.PACKAGE_APISIX_VERSION }}-0~ubuntu20.04_amd64.deb
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-openresty-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-openresty-deb-ubuntu20.04.yml
@@ -54,4 +54,5 @@ jobs:
         with:
           name: apisix-openresty_${{ env.BUILD_APISIX_OR_VERSION }}-0~ubuntu20.04_amd64.deb
           path: output/apisix-openresty_${{ env.BUILD_APISIX_OR_VERSION }}-0~ubuntu20.04_amd64.deb
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-openresty-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-openresty-deb-ubuntu20.04.yml
@@ -48,3 +48,10 @@ jobs:
         run: |
           export APISIX_OPENRESTY_VER=$(docker exec ubuntu20.04Instance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_OPENRESTY_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_OPENRESTY_VER" != "${BUILD_APISIX_OR_VERSION}" ]; then exit 1; fi
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix-openresty_${{ env.BUILD_APISIX_OR_VERSION }}-0~ubuntu20.04_amd64.deb
+          path: output/apisix-openresty_${{ env.BUILD_APISIX_OR_VERSION }}-0~ubuntu20.04_amd64.deb
+          if-no-files-found: error

--- a/.github/workflows/package-apisix-openresty-rpm-el7.yml
+++ b/.github/workflows/package-apisix-openresty-rpm-el7.yml
@@ -49,4 +49,5 @@ jobs:
         with:
           name: apisix-openresty-${{ env.BUILD_APISIX_OR_VERSION }}-0.el7.x86_64.rpm
           path: output/apisix-openresty-${{ env.BUILD_APISIX_OR_VERSION }}-0.el7.x86_64.rpm
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-openresty-rpm-el7.yml
+++ b/.github/workflows/package-apisix-openresty-rpm-el7.yml
@@ -43,3 +43,10 @@ jobs:
         run: |
           export APISIX_OPENRESTY_VER=$(docker exec centos7Instance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_OPENRESTY_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_OPENRESTY_VER" != "${BUILD_APISIX_OR_VERSION}" ]; then exit 1; fi
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix-openresty-${{ env.BUILD_APISIX_OR_VERSION }}-0.el7.x86_64.rpm
+          path: output/apisix-openresty-${{ env.BUILD_APISIX_OR_VERSION }}-0.el7.x86_64.rpm
+          if-no-files-found: error

--- a/.github/workflows/package-apisix-rpm-el7-with-apisix-openresty.yml
+++ b/.github/workflows/package-apisix-rpm-el7-with-apisix-openresty.yml
@@ -37,7 +37,6 @@ jobs:
       - name: packaging APISIX
         run: |
           make package type=rpm app=apisix version=2.7 checkout=release/2.7 image_base=centos image_tag=7 openresty=apisix-openresty
-          make package type=rpm app=apisix version=2.9 checkout=release/2.9 image_base=centos image_tag=7 openresty=apisix-openresty
           make package type=rpm app=apisix version=master checkout=master image_base=centos image_tag=7 openresty=apisix-openresty
 
       - name: packaging apisix-openresty
@@ -78,6 +77,7 @@ jobs:
       - name: Publish Artifact
         uses: actions/upload-artifact@v2.2.4
         with:
-          name: apisix-2.9-0.el7.x86_64.rpm that depends on apisix-openresty
-          path: output/apisix-2.9-0.el7.x86_64.rpm
+          name: apisix-master-0.el7.x86_64.rpm that depends on apisix-openresty
+          path: output/apisix-master-0.el7.x86_64.rpm
+          retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-rpm-el7-with-apisix-openresty.yml
+++ b/.github/workflows/package-apisix-rpm-el7-with-apisix-openresty.yml
@@ -37,6 +37,7 @@ jobs:
       - name: packaging APISIX
         run: |
           make package type=rpm app=apisix version=2.7 checkout=release/2.7 image_base=centos image_tag=7 openresty=apisix-openresty
+          make package type=rpm app=apisix version=2.9 checkout=release/2.9 image_base=centos image_tag=7 openresty=apisix-openresty
           make package type=rpm app=apisix version=master checkout=master image_base=centos image_tag=7 openresty=apisix-openresty
 
       - name: packaging apisix-openresty
@@ -73,3 +74,10 @@ jobs:
               echo "failed: failed to install Apache APISIX by rpm"
               exit 1
           fi
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: apisix-2.9-0.el7.x86_64.rpm that depends on apisix-openresty
+          path: output/apisix-2.9-0.el7.x86_64.rpm
+          if-no-files-found: error


### PR DESCRIPTION
Changes proposed with this PR:
1. Upload the rpms of apisix-openresty, apisix that depends on apisix-openresty;
2. Upload the debs of apisix-openresty, apisix, dashboard;
3. Bump the versions of apisix, dashboard;


Signed-off-by: imjoey <majunjie@apache.org>