### PR TITLE
chore: Ignore cert check when downloading openresty

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -24,7 +24,7 @@ workdir=$(mktemp -d)
 cd "$workdir" || exit 1
 
 or_ver="1.19.3.2"
-wget https://openresty.org/download/openresty-${or_ver}.tar.gz
+wget --no-check-certificate https://openresty.org/download/openresty-${or_ver}.tar.gz
 tar -zxvpf openresty-${or_ver}.tar.gz
 
 if [ "$repo" == ngx_multi_upstream_module ]; then


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

This PR is going to add the `--no-check-certificate` option for wget command, in order to eliminate the following occasional errors during downloading openresty in CI:

```
+ wget https://openresty.org/download/openresty-1.19.3.2.tar.gz
--2021-10-08 05:30:38--  https://openresty.org/download/openresty-1.19.3.2.tar.gz
Resolving openresty.org (openresty.org)... 3.131.85.84, 2604:a880:2:d0::381e:1
Connecting to openresty.org (openresty.org)|3.131.85.84|:443... connected.
ERROR: cannot verify openresty.org's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=R3':
  Issued certificate has expired.
To connect to openresty.org insecurely, use `--no-check-certificate'.
```