### PR TITLE
fix: Add ldap dev dependency for building apisix

### DIFF
--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -79,6 +79,8 @@ install_etcd() {
 }
 
 install_apisix() {
+    # show awk version
+    awk --version
     mkdir -p /tmp/build/output/apisix/usr/bin/
     cd /apisix
     # remove useless code for build

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -44,7 +44,7 @@ install_lua() {
 install_openresty_deb() {
     # install openresty and openssl111
     DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libssl-dev perl build-essential
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libldap2-dev libssl-dev perl build-essential
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
     wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
     echo "deb http://openresty.org/package/ubuntu $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/openresty.list
@@ -55,7 +55,7 @@ install_openresty_deb() {
 install_openresty_rpm() {
     # install openresty and openssl111
     yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum install -y openresty openresty-openssl111-devel pcre pcre-devel
+    yum install -y openresty openresty-openssl111-devel pcre pcre-devel openldap-devel
 }
 
 install_luarocks() {

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -27,7 +27,7 @@ install_dependencies_rpm() {
 install_dependencies_deb() {
     # install basic dependencies
     DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y wget tar gcc automake autoconf libtool make curl git unzip libreadline-dev lsb-release
+    DEBIAN_FRONTEND=noninteractive apt-get install -y wget tar gcc automake autoconf libtool make curl git unzip libreadline-dev lsb-release gawk
 
     # install lua 5.1 for compatible with openresty 1.17.8.2
     install_lua


### PR DESCRIPTION
Since the latest APISIX, from the master branch,  has already supported the ldap-auth plugin. So in order to build APISIX successfully, this PR is going to add the required openldap devel library, just as what did in https://github.com/apache/apisix-docker/pull/222.


Signed-off-by: imjoey <majunjie@apache.org>