### PR TITLE
ci: Fix incorrect shebang in rpm package for 2.10.x

### DIFF
--- a/.github/workflows/package-apisix-rpm-el7.yml
+++ b/.github/workflows/package-apisix-rpm-el7.yml
@@ -40,6 +40,7 @@ jobs:
       - name: packaging APISIX(-remote) with remote code
         run: |
           make package type=rpm app=apisix version=2.7 checkout=release/2.7 image_base=centos image_tag=7 artifact=apisix-remote
+          make package type=rpm app=apisix version=2.10.1 checkout=2.10.1 image_base=centos image_tag=7 artifact=apisix-remote
           make package type=rpm app=apisix version=master checkout=master image_base=centos image_tag=7 artifact=apisix-remote
 
       - name: packaging APISIX(-local) with local code
@@ -56,12 +57,12 @@ jobs:
           docker exec centos7Instance bash -c "rpm --import https://repos.apiseven.com/KEYS"
           docker exec centos7Instance bash -c "yum -y install https://repos.apiseven.com/packages/centos/apache-apisix-repo-1.0-1.noarch.rpm"
 
-      - name: install APISIX(-remote) by rpm in container
+      - name: install APISIX(-remote) master by rpm in container
         run: |
           docker exec centos7Instance bash -c "yum -y localinstall /output/apisix-remote-master-0.el7.x86_64.rpm"
           docker exec centos7Instance bash -c "apisix start"
 
-      - name: check and ensure APISIX(-remote) is installed
+      - name: check and ensure APISIX(-remote) master is installed
         run: |
           code=$(curl -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/admin/routes -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1')
           if [ ! $code -eq 200 ]; then
@@ -69,10 +70,28 @@ jobs:
               exit 1
           fi
 
-      - name: stop and uninstall APISIX(-remote)
+      - name: stop and uninstall APISIX(-remote) master
         run: |
           docker exec centos7Instance bash -c "pkill -f nginx"
           docker exec centos7Instance bash -c "yum -y erase apisix-remote-master"
+
+      - name: install APISIX(-remote) 2.10.1 by rpm in container
+        run: |
+          docker exec centos7Instance bash -c "yum -y localinstall /output/apisix-remote-2.10.1-0.el7.x86_64.rpm"
+          docker exec centos7Instance bash -c "apisix start"
+
+      - name: check and ensure APISIX(-remote) 2.10.1 is installed
+        run: |
+          code=$(curl -k -i -m 20 -o /dev/null -s -w %{http_code} http://127.0.0.1:9080/apisix/admin/routes -H 'X-API-KEY: edd1c9f034335f136f87ad84b625c8f1')
+          if [ ! $code -eq 200 ]; then
+              echo "failed: failed to install Apache APISIX by rpm"
+              exit 1
+          fi
+
+      - name: stop and uninstall APISIX(-remote) 2.10.1
+        run: |
+          docker exec centos7Instance bash -c "pkill -f nginx"
+          docker exec centos7Instance bash -c "yum -y erase apisix-remote-2.10.1"
 
       - name: install APISIX(-local) by rpm in container
         run: |


### PR DESCRIPTION
Signed-off-by: imjoey <majunjie@apache.org>

Will fixes #107. 

This PR is going to fix the incorrect semantic versioning comparaion result in shell, which leads to `2.10.1` < `2.2`. That would causes adding incorrect shebang specified only for much older versions. Meanwhile, for the `master` and `release/***` branches, we will always consider them as newer versions.

This PR also add related CI checks using the promblematic version `2.10.1`.