### PR TITLE
feat: update apisix-base to cross-compile on minideb

### DIFF
--- a/.github/workflows/push-apisix-base-image.yml
+++ b/.github/workflows/push-apisix-base-image.yml
@@ -45,4 +45,4 @@ jobs:
         run: |
           docker buildx build -t api7/apisix-base:${{ steps.tag_env.outputs.version }} --push \
             --build-arg VERSION=${{ steps.tag_env.outputs.version }} --platform linux/amd64,linux/arm64 \
-            -f ./dockerfiles/Dockerfile.apisix-base.apk .
+            -f ./dockerfiles/Dockerfile.apisix-base.minideb .

--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -88,6 +88,7 @@ cd apisix-nginx-module/patch || exit 1
 cd ../..
 
 cd wasm-nginx-module || exit 1
+if [ "${TARGETARCH}" = "arm64" ] ; then sed -i 's/x86_64/aarch64/g' ./install-wasmtime.sh; fi
 ./install-wasmtime.sh
 cd ..
 

--- a/dockerfiles/Dockerfile.apisix-base.minideb
+++ b/dockerfiles/Dockerfile.apisix-base.minideb
@@ -1,0 +1,113 @@
+FROM --platform=amd64 bitnami/minideb:bullseye as build
+
+COPY ./utils/build-common.sh \
+     ./utils/install-common.sh \
+     build-apisix-base.sh \
+     ./utils/determine-dist.sh \
+     /tmp/
+
+ARG RESTY_OPENSSL_VERSION="1.1.1g"
+ARG RESTY_OPENSSL_PATCH_VERSION="1.1.1f"
+ARG RESTY_OPENSSL_URL_BASE="https://www.openssl.org/source"
+ARG RESTY_PCRE_VERSION="8.44"
+ARG RESTY_J="1"
+ARG RESTY_EVAL_PRE_CONFIGURE=""
+ARG VERSION
+ARG TARGETARCH
+
+LABEL resty_image_base="${RESTY_IMAGE_BASE}"
+LABEL resty_image_tag="${IMAGE_TAG}"
+LABEL resty_openssl_version="${RESTY_OPENSSL_VERSION}"
+LABEL resty_openssl_patch_version="${RESTY_OPENSSL_PATCH_VERSION}"
+LABEL resty_openssl_url_base="${RESTY_OPENSSL_URL_BASE}"
+LABEL resty_pcre_version="${RESTY_PCRE_VERSION}"
+LABEL resty_eval_pre_configure="${RESTY_EVAL_PRE_CONFIGURE}"
+
+RUN dpkg --add-architecture ${TARGETARCH} \
+    && install_packages ca-certificates \
+                        curl \
+                        wget \
+                        git \
+                        gettext-base \
+                        patch \
+                        xz-utils \
+                        sudo \
+                        make \
+                        perl \
+                        unzip \
+                        libgd-dev:${TARGETARCH} \
+                        libgeoip-dev:${TARGETARCH} \
+                        libncurses5-dev:${TARGETARCH} \
+                        libperl-dev:${TARGETARCH} \
+                        libreadline-dev:${TARGETARCH} \
+                        libxslt1-dev:${TARGETARCH} \
+                        zlib1g-dev:${TARGETARCH} \
+    && if [ "${TARGETARCH}" = "amd64" ] ; then install_packages gcc g++; fi \
+    && if [ "${TARGETARCH}" = "arm64" ] ; then \
+        install_packages gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
+        ln /usr/bin/aarch64-linux-gnu-gcc /usr/bin/cc; \
+        ln /usr/bin/aarch64-linux-gnu-gcc /usr/bin/gcc; \
+        ln /usr/bin/aarch64-linux-gnu-ar /usr/bin/ar; \
+        ln /usr/bin/aarch64-linux-gnu-ranlib /usr/bin/ranlib; \
+        ln /usr/bin/aarch64-linux-gnu-g++ /usr/bin/g++; \
+    fi \
+    && gcc -v \
+    && g++ -v
+
+RUN echo ${TARGETARCH} \
+    && cd /tmp \
+    && if [ -n "${RESTY_EVAL_PRE_CONFIGURE}" ]; then eval $(echo ${RESTY_EVAL_PRE_CONFIGURE}); fi \
+    && cd /tmp \
+    && curl -fSL "${RESTY_OPENSSL_URL_BASE}/openssl-${RESTY_OPENSSL_VERSION}.tar.gz" -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+    && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
+    && cd openssl-${RESTY_OPENSSL_VERSION} \
+    && echo 'patching OpenSSL 1.1.1 for OpenResty' \
+    && curl -s https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-${RESTY_OPENSSL_PATCH_VERSION}-sess_set_get_cb_yield.patch | patch -p1 \
+    && if [ "${TARGETARCH}" = "arm64" ] ; then export MACHINE=aarch64; fi \
+    && ./config \
+      no-threads shared zlib -g \
+      enable-ssl3 enable-ssl3-method \
+      --prefix=/usr/local/openresty/openssl111 \
+      --libdir=lib \
+      -Wl,-rpath,/usr/local/openresty/openssl111/lib \
+    && make -j${RESTY_J} \
+    && make -j${RESTY_J} install_sw
+
+RUN echo ${TARGETARCH} \
+    && cd /tmp \
+    && curl -fSL https://downloads.sourceforge.net/project/pcre/pcre/${RESTY_PCRE_VERSION}/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && cd /tmp/pcre-${RESTY_PCRE_VERSION} \
+    && ./configure \
+        --prefix=/usr/local/openresty/pcre \
+        --disable-cpp \
+        --enable-jit \
+        --enable-utf \
+        --enable-unicode-properties \
+    && make -j${RESTY_J} \
+    && make -j${RESTY_J} install
+
+ENV version=${VERSION}
+ENV TARGETARCH=${TARGETARCH}
+
+RUN echo ${TARGETARCH} \
+    && cd /tmp \
+    && curl --version \
+    && ./build-common.sh build_apisix_base_minideb \
+    && ./install-common.sh install_lua \
+    && ./install-common.sh install_luarocks \
+    && /usr/local/openresty/bin/openresty -V
+
+FROM bitnami/minideb:bullseye as prod
+
+COPY --from=build /usr/local/openresty /usr/local/openresty
+
+RUN install_packages libgd3 \
+                     libgeoip1 \
+                     libxslt1.1 \
+                     zlib1g \
+    && rm /usr/local/openresty/wasmtime-c-api/lib/libwasmtime.a
+
+ENV PATH=$PATH:/usr/local/openresty/luajit/bin:/usr/local/openresty/nginx/sbin:/usr/local/openresty/bin
+
+CMD /bin/sh

--- a/utils/build-common.sh
+++ b/utils/build-common.sh
@@ -31,6 +31,11 @@ build_apisix_base_deb() {
     ./build-apisix-base.sh
 }
 
+build_apisix_base_minideb() {
+    export_openresty_variables
+    ./build-apisix-base.sh
+}
+
 build_apisix_base_apk() {
     export_openresty_variables
     ./build-apisix-base.sh
@@ -54,6 +59,9 @@ build_apisix_base_rpm)
     ;;
 build_apisix_base_deb)
     build_apisix_base_deb
+    ;;
+build_apisix_base_minideb)
+    build_apisix_base_minideb
     ;;
 build_apisix_base_apk)
     build_apisix_base_apk


### PR DESCRIPTION
- [x] change base image to minideb "bullseye - 11" (The bitnami‘s image is usually used in a debian-based cropped version)
- [x] nearly 50x speedup by using of full cross-compilation