### PR TITLE
chore: migrate centos patch to dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.apisix-base.rpm
+++ b/dockerfiles/Dockerfile.apisix-base.rpm
@@ -3,6 +3,15 @@ ARG IMAGE_TAG="7"
 
 FROM ${IMAGE_BASE}:${IMAGE_TAG}
 
+RUN if [[ $(rpm --eval '%{centos_ver}') == "8" ]]; then \
+        sed -re "s/^#?\s*(mirrorlist)/#\1/g" \
+             -e "s|^#?\s*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
+             -i /etc/yum.repos.d/CentOS-Linux-*; \
+        dnf install -y centos-release-stream; \
+        dnf swap -y centos-{linux,stream}-repos; \
+        dnf distro-sync -y; \
+    fi
+
 COPY ./utils/build-common.sh /tmp/build-common.sh
 COPY build-apisix-base.sh /tmp/build-apisix-base.sh
 COPY ./utils/determine-dist.sh /tmp/determine-dist.sh

--- a/dockerfiles/Dockerfile.apisix.rpm
+++ b/dockerfiles/Dockerfile.apisix.rpm
@@ -3,6 +3,15 @@ ARG IMAGE_TAG="7"
 
 FROM ${IMAGE_BASE}:${IMAGE_TAG}
 
+RUN if [[ $(rpm --eval '%{centos_ver}') == "8" ]]; then \
+        sed -re "s/^#?\s*(mirrorlist)/#\1/g" \
+             -e "s|^#?\s*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
+             -i /etc/yum.repos.d/CentOS-Linux-*; \
+        dnf install -y centos-release-stream; \
+        dnf swap -y centos-{linux,stream}-repos; \
+        dnf distro-sync -y; \
+    fi
+
 COPY ./utils/install-common.sh /install-common.sh
 COPY ./utils/determine-dist.sh /determine-dist.sh
 

--- a/dockerfiles/Dockerfile.dashboard.rpm
+++ b/dockerfiles/Dockerfile.dashboard.rpm
@@ -3,6 +3,15 @@ ARG IMAGE_TAG="7"
 
 FROM ${IMAGE_BASE}:${IMAGE_TAG}
 
+RUN if [[ $(rpm --eval '%{centos_ver}') == "8" ]]; then \
+        sed -re "s/^#?\s*(mirrorlist)/#\1/g" \
+             -e "s|^#?\s*baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
+             -i /etc/yum.repos.d/CentOS-Linux-*; \
+        dnf install -y centos-release-stream; \
+        dnf swap -y centos-{linux,stream}-repos; \
+        dnf distro-sync -y; \
+    fi
+
 COPY ./utils/install-common.sh /install-common.sh
 COPY ./utils/determine-dist.sh /determine-dist.sh
 

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -2,20 +2,6 @@
 set -euo pipefail
 set -x
 
-patch_centos8_repo() {
-    if [[ $(rpm --eval '%{centos_ver}') != "8" ]]; then
-        return
-    fi
-    # switch yum repo source
-    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
-
-    # rebuild repo cache
-    dnf install -y centos-release-stream
-    dnf swap -y centos-{linux,stream}-repos
-    dnf distro-sync -y
-}
-
 install_apisix_dependencies_deb() {
     install_dependencies_deb
     install_openresty_deb
@@ -23,16 +9,12 @@ install_apisix_dependencies_deb() {
 }
 
 install_apisix_dependencies_rpm() {
-    patch_centos8_repo
-
     install_dependencies_rpm
     install_openresty_rpm
     install_luarocks
 }
 
 install_dependencies_rpm() {
-    patch_centos8_repo
-
     # install basic dependencies
     yum -y install wget tar gcc automake autoconf libtool make curl git which unzip sudo
     yum -y install epel-release
@@ -129,8 +111,6 @@ install_golang() {
 }
 
 install_dashboard_dependencies_rpm() {
-    patch_centos8_repo
-
     yum install -y wget curl git which gcc make
     curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
     sh -c "$(curl -fsSL https://rpm.nodesource.com/setup_14.x)"


### PR DESCRIPTION
It's not a good idea to maintain repo patch in utils script, it should be maintained by the container description file `Dockerfile` itself.

Benefits:
1. Reusable container filesystem layer cache
2. No more double-checking of repo patch in utils scripts