### PR TITLE
feat: add ci repo support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-18.04
     timeout-minutes: 60
     env:
-      VAR_ALIYUN_OSS_BUCKET: ${{ secrets.VAR_ALIYUN_OSS_BUCKET }}
-      VAR_ALIYUN_OSS_ENDPOINT: ${{ secrets.VAR_ALIYUN_OSS_ENDPOINT }}
+      VAR_OSS_BUCKET_CI: ${{ secrets.VAR_OSS_BUCKET_CI }}
+      VAR_OSS_BUCKET_REPO: ${{ secrets.VAR_OSS_BUCKET_REPO }}
+      VAR_OSS_ENDPOINT: ${{ secrets.VAR_OSS_ENDPOINT }}
       VAR_RPM_WORKBENCH_DIR: /tmp/output
 
     steps:
@@ -117,8 +118,8 @@ jobs:
 
       - name: RPM repo package update
         env:
-          GPG_NAME: "APISIX Publisher"
-          GPG_MAIL: "<dev@apisix.apache.org>"
+          GPG_NAME: ${{ secrets.GPG_NAME }}
+          GPG_MAIL: ${{ secrets.GPG_MAIL }}
         run: |
           echo "${{ secrets.RPM_GPG_PRIV_KEY }}" >> /tmp/rpm-gpg-publish.private
           echo "${{ secrets.RPM_GPG_PASSPHRASE }}" >> /tmp/rpm-gpg-publish.passphrase

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,6 +136,10 @@ jobs:
           sudo -E ./utils/publish-rpm.sh repo_repodata_rebuild
           sudo -E ./utils/publish-rpm.sh repo_upload
 
-      - name: RPM repo remove backup
+      - name: RPM repo verify
         run: |
-          sudo -E ./utils/publish-rpm.sh repo_backup_remove
+          echo "verify"
+
+      - name: RPM repo publish
+        run: |
+          sudo -E ./utils/publish-rpm.sh repo_publish

--- a/utils/publish-rpm.sh
+++ b/utils/publish-rpm.sh
@@ -8,7 +8,6 @@ set -x
 # Runtime default config
 # =======================================
 VAR_ALIYUN_OSS_UTILS_VERSION=${VAR_ALIYUN_OSS_UTILS_VERSION:-1.7.10}
-VAR_ALIYUN_OSS_ENDPOINT=${VAR_ALIYUN_OSS_ENDPOINT:-endpoint=oss-cn-shenzhen.aliyuncs.com}
 VAR_RPM_WORKBENCH_DIR=${VAR_RPM_WORKBENCH_DIR:-/tmp/output}
 VAR_GPG_PRIV_KET=${VAR_GPG_PRIV_KET:-/tmp/rpm-gpg-publish.private}
 VAR_GPG_PASSPHRASE=${VAR_GPG_PASSPHRASE:-/tmp/rpm-gpg-publish.passphrase}
@@ -119,7 +118,7 @@ case_opt=$1
 case ${case_opt} in
 init_oss_utils)
     func_oss_utils_install "${VAR_ALIYUN_OSS_UTILS_VERSION}"
-    func_oss_utils_credential_init "${VAR_ALIYUN_OSS_ENDPOINT}" "${ACCESS_KEY_ID}" "${ACCESS_KEY_SECRET}"
+    func_oss_utils_credential_init "${VAR_OSS_ENDPOINT}" "${ACCESS_KEY_ID}" "${ACCESS_KEY_SECRET}"
     ;;
 repo_init)
     # create basic repo directory structure
@@ -127,10 +126,10 @@ repo_init)
     func_repo_init /tmp
     ;;
 repo_backup)
-    func_repo_backup "${VAR_ALIYUN_OSS_BUCKET}" "centos" "${TAG_DATE}"
+    func_repo_backup "${VAR_OSS_BUCKET_REPO}" "centos" "${TAG_DATE}"
     ;;
 repo_clone)
-    func_repo_clone "${VAR_ALIYUN_OSS_BUCKET}" "centos" /tmp
+    func_repo_clone "${VAR_OSS_BUCKET_REPO}" "centos" /tmp
     ;;
 repo_package_sync)
     VAR_REPO_MAJOR_VER=(7 8)
@@ -145,10 +144,10 @@ repo_repodata_rebuild)
     func_repo_repodata_sign /tmp/centos
     ;;
 repo_upload)
-    func_repo_upload /tmp/centos "${VAR_ALIYUN_OSS_BUCKET}" "centos"
+    func_repo_upload /tmp/centos "${VAR_OSS_BUCKET_REPO}" "centos"
     ;;
 repo_backup_remove)
-    func_repo_backup_remove "${VAR_ALIYUN_OSS_BUCKET}" "centos" "${TAG_DATE}"
+    func_repo_backup_remove "${VAR_OSS_BUCKET_REPO}" "centos" "${TAG_DATE}"
     ;;
 rpm_gpg_sign)
     func_rpmsign_macros_init

--- a/utils/publish-rpm.sh
+++ b/utils/publish-rpm.sh
@@ -115,7 +115,7 @@ func_repo_publish() {
     # ${2} - repo publish bucket
     # ${3} - OSS path
     ossutil64 rm -r -f "oss://${2}/packages/${3}"
-    ossutil64 cp -r "oss://${1}/packages/${3}" "oss://${2}/packages/${3}"
+    ossutil64 cp -r "oss://${1}/packages/${3}" "oss://${2}/packages"
 }
 
 # =======================================

--- a/utils/publish-rpm.sh
+++ b/utils/publish-rpm.sh
@@ -155,7 +155,7 @@ repo_upload)
     func_repo_upload /tmp/centos "${VAR_OSS_BUCKET_CI}" "centos"
     ;;
 repo_publish)
-    func_repo_publish "${VAR_OSS_BUCKET_CI}" "${VAR_OSS_BUCKET_REPO}"
+    func_repo_publish "${VAR_OSS_BUCKET_CI}" "${VAR_OSS_BUCKET_REPO}" "centos"
     ;;
 repo_backup_remove)
     func_repo_backup_remove "${VAR_OSS_BUCKET_REPO}" "centos" "${TAG_DATE}"

--- a/utils/publish-rpm.sh
+++ b/utils/publish-rpm.sh
@@ -144,7 +144,10 @@ repo_repodata_rebuild)
     func_repo_repodata_sign /tmp/centos
     ;;
 repo_upload)
-    func_repo_upload /tmp/centos "${VAR_OSS_BUCKET_REPO}" "centos"
+    func_repo_upload /tmp/centos "${VAR_OSS_BUCKET_CI}" "centos"
+    ;;
+repo_publish)
+    ossutil64 cp -r "${VAR_OSS_BUCKET_CI}" "${VAR_OSS_BUCKET_REPO}"
     ;;
 repo_backup_remove)
     func_repo_backup_remove "${VAR_OSS_BUCKET_REPO}" "centos" "${TAG_DATE}"

--- a/utils/publish-rpm.sh
+++ b/utils/publish-rpm.sh
@@ -110,6 +110,14 @@ func_repo_upload() {
     ossutil64 cp -r "${1}" "oss://${2}/packages/${3}"
 }
 
+func_repo_publish() {
+    # ${1} - CI bucket
+    # ${2} - repo publish bucket
+    # ${3} - OSS path
+    ossutil64 rm -r -f "oss://${2}/packages/${3}"
+    ossutil64 cp -r "oss://${1}/packages/${3}" "oss://${2}/packages/${3}"
+}
+
 # =======================================
 # publish utils entry
 # =======================================
@@ -147,7 +155,7 @@ repo_upload)
     func_repo_upload /tmp/centos "${VAR_OSS_BUCKET_CI}" "centos"
     ;;
 repo_publish)
-    ossutil64 cp -r "oss://${VAR_OSS_BUCKET_CI}" "oss://${VAR_OSS_BUCKET_REPO}"
+    func_repo_publish "${VAR_OSS_BUCKET_CI}" "${VAR_OSS_BUCKET_REPO}"
     ;;
 repo_backup_remove)
     func_repo_backup_remove "${VAR_OSS_BUCKET_REPO}" "centos" "${TAG_DATE}"

--- a/utils/publish-rpm.sh
+++ b/utils/publish-rpm.sh
@@ -147,7 +147,7 @@ repo_upload)
     func_repo_upload /tmp/centos "${VAR_OSS_BUCKET_CI}" "centos"
     ;;
 repo_publish)
-    ossutil64 cp -r "${VAR_OSS_BUCKET_CI}" "${VAR_OSS_BUCKET_REPO}"
+    ossutil64 cp -r "oss://${VAR_OSS_BUCKET_CI}" "oss://${VAR_OSS_BUCKET_REPO}"
     ;;
 repo_backup_remove)
     func_repo_backup_remove "${VAR_OSS_BUCKET_REPO}" "centos" "${TAG_DATE}"


### PR DESCRIPTION
Now CI will upload the repo directly to CI bucket instead of production bucket, then copy the CI bucket to the production bucket to reduce the service unavailability time.