### PR TITLE
fix(utils): fix support for Debian

### DIFF
--- a/utils/determine-dist.sh
+++ b/utils/determine-dist.sh
@@ -9,6 +9,9 @@ then
 elif [ "${IMAGE_BASE}" == "ubuntu" ]
 then
     dist="${IMAGE_BASE}${IMAGE_TAG}"
+elif [ "${IMAGE_BASE}" == "debian" ]
+then
+    dist="${IMAGE_BASE}${IMAGE_TAG}"
 fi
 
 echo "${dist}" > /tmp/dist

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -39,7 +39,15 @@ install_openresty_deb() {
     DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libldap2-dev libssl-dev perl build-essential
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
     wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
-    echo "deb http://openresty.org/package/${arch_path}ubuntu $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/openresty.list
+
+    if [[ $IMAGE_BASE == "ubuntu" ]]; then
+        echo "deb http://openresty.org/package/${arch_path}ubuntu $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/openresty.list
+    fi
+
+    if [[ $IMAGE_BASE == "debian" ]]; then
+        echo "deb http://openresty.org/package/${arch_path}debian $(lsb_release -sc) openresty" | tee /etc/apt/sources.list.d/openresty.list
+    fi
+
     DEBIAN_FRONTEND=noninteractive apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -y openresty-openssl111-dev openresty
 }


### PR DESCRIPTION
Fixed building for Debian, as `type=deb` `image_base=debian`.

Tested for Bullseye `image_tag=11`, Buster `image_tag=10` and Stretch `image_tag=9`.