### PR TITLE
fix: incorrect codename when packaging

### DIFF
--- a/dockerfiles/Dockerfile.apisix-base.deb
+++ b/dockerfiles/Dockerfile.apisix-base.deb
@@ -27,3 +27,4 @@ FROM ${IMAGE_BASE}:${IMAGE_TAG} as prod
 
 COPY --from=build /usr/local /usr/local
 COPY --from=build /tmp/dist /tmp/dist
+COPY --from=build /tmp/codename /tmp/codename

--- a/dockerfiles/Dockerfile.package.apisix
+++ b/dockerfiles/Dockerfile.package.apisix
@@ -18,6 +18,7 @@ ENV ARTIFACT=${ARTIFACT}
 
 COPY --from=APISIX /tmp/build/output /tmp/build/output
 COPY --from=APISIX /tmp/dist /tmp/dist
+COPY --from=APISIX /tmp/codename /tmp/codename
 COPY package-apisix.sh /package-apisix.sh
 COPY usr /usr
 

--- a/dockerfiles/Dockerfile.package.apisix-base
+++ b/dockerfiles/Dockerfile.package.apisix-base
@@ -16,6 +16,7 @@ ENV ARTIFACT=${ARTIFACT}
 
 COPY --from=APISIX-BASE /usr/local/openresty /tmp/build/output/openresty
 COPY --from=APISIX-BASE /tmp/dist /tmp/dist
+COPY --from=APISIX-BASE /tmp/codename /tmp/codename
 COPY package-apisix-base.sh /package-apisix-base.sh
 COPY post-install-apisix-base.sh /post-install-apisix-base.sh
 COPY usr /usr

--- a/dockerfiles/Dockerfile.package.apisix-dashboard
+++ b/dockerfiles/Dockerfile.package.apisix-dashboard
@@ -16,6 +16,7 @@ ENV ARTIFACT=${ARTIFACT}
 
 COPY --from=APISIX /tmp/build/output /tmp/build/output
 COPY --from=APISIX /tmp/dist /tmp/dist
+COPY --from=APISIX /tmp/codename /tmp/codename
 COPY package-apisix-dashboard.sh /package-apisix-dashboard.sh
 COPY usr /usr
 

--- a/package-apisix-base.sh
+++ b/package-apisix-base.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 set -x
 mkdir /output
 dist=$(cat /tmp/dist)
+codename=$(cat /tmp/codename)
 
 # Determine the name of artifact
 # The defaut is apisix-base
@@ -17,7 +18,6 @@ openresty_zlib_version="1.2.12-1"
 openresty_openssl111_version="1.1.1n-1"
 openresty_pcre_version="8.45-1"
 if [ "$PACKAGE_TYPE" == "deb" ]; then
-    codename=`cat /etc/os-release |grep VERSION_CODENAME|awk -F '=' '{print $2}'`
     pkg_suffix="${codename}1"
     openresty_zlib_version="$openresty_zlib_version~$pkg_suffix"
     openresty_openssl111_version="$openresty_openssl111_version~$pkg_suffix"

--- a/utils/determine-dist.sh
+++ b/utils/determine-dist.sh
@@ -15,3 +15,5 @@ then
 fi
 
 echo "${dist}" > /tmp/dist
+
+echo `cat /etc/os-release |grep VERSION_CODENAME|awk -F '=' '{print $2}'` > /tmp/codename


### PR DESCRIPTION
Get codemae when building, not when you packaging. This ensures that the correct openresty dependency package information is written when packaging.