### PR TITLE
fix: remove the default value of goproxy

### DIFF
--- a/dockerfiles/Dockerfile.dashboard.deb
+++ b/dockerfiles/Dockerfile.dashboard.deb
@@ -11,7 +11,7 @@ RUN /install-common.sh install_dashboard_dependencies_deb
 
 ARG checkout_v="v2.3"
 ARG iteration="0"
-ARG goproxy="https://proxy.golang.com.cn,direct"
+ARG goproxy
 ARG IMAGE_BASE
 ARG IMAGE_TAG
 ARG CODE_PATH

--- a/dockerfiles/Dockerfile.dashboard.deb
+++ b/dockerfiles/Dockerfile.dashboard.deb
@@ -11,7 +11,7 @@ RUN /install-common.sh install_dashboard_dependencies_deb
 
 ARG checkout_v="v2.3"
 ARG iteration="0"
-ARG goproxy
+ARG goproxy=""
 ARG IMAGE_BASE
 ARG IMAGE_TAG
 ARG CODE_PATH

--- a/dockerfiles/Dockerfile.dashboard.rpm
+++ b/dockerfiles/Dockerfile.dashboard.rpm
@@ -22,7 +22,7 @@ RUN /install-common.sh install_dashboard_dependencies_rpm
 
 ARG checkout_v="v2.3"
 ARG iteration="0"
-ARG goproxy="https://proxy.golang.com.cn,direct"
+ARG goproxy
 ARG IMAGE_BASE
 ARG IMAGE_TAG
 ARG CODE_PATH

--- a/dockerfiles/Dockerfile.dashboard.rpm
+++ b/dockerfiles/Dockerfile.dashboard.rpm
@@ -22,7 +22,7 @@ RUN /install-common.sh install_dashboard_dependencies_rpm
 
 ARG checkout_v="v2.3"
 ARG iteration="0"
-ARG goproxy
+ARG goproxy=""
 ARG IMAGE_BASE
 ARG IMAGE_TAG
 ARG CODE_PATH


### PR DESCRIPTION
Remove the default GOPROXY value used when building the APISIX Dashboard, it will break our CI build process.

It turns out that we use the proxy service provided by `https://proxy.golang.com.cn`, which often responds with `502 Bad Gateway` in GitHub CI and fails to provide normal service.