### PR TITLE
feat: Improve pnpm support for dashboard build scripts.

### DIFF
--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -136,7 +136,6 @@ install_dashboard_dependencies_rpm() {
     curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
     sh -c "$(curl -fsSL https://rpm.nodesource.com/setup_14.x)"
     yum install -y nodejs yarn
-    corepack enable
     npm install -g pnpm
     install_golang
 }


### PR DESCRIPTION
I am working on the APISIX dashboard project to migrate its package manager from yarn to pnpm. His GitHub workflow uses this script to detect RPM packaging. We need some minor changes to make the workflow work normally.