### PR TITLE
fix: unable to locate package createrepo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,11 @@
 name: Build and Publish Package
 
 on:
-  push:
-    branches: [ createrepo ]
+  create
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish_apisix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,13 @@
 name: Build and Publish Package
 
 on:
-  create
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/master' && github.run_number || github.ref }}
-  cancel-in-progress: true
+  push:
+    branches: [ createrepo ]
 
 jobs:
   publish_apisix:
     name: Build and Publish RPM Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     timeout-minutes: 60
     env:
       VAR_COS_BUCKET_CI: ${{ secrets.VAR_COS_BUCKET_CI }}


### PR DESCRIPTION
Since createrepo is deprecated in the latest ubuntu 20.04 version, use ubuntu 18.04 as a temporary solution.
We will look for alternatives to createrepo in the future.