### PR TITLE
ci: rollback to ubuntu-18.04 as 20.04 doesn't have createrepo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   publish_apisix:
     name: Build and Publish RPM Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     timeout-minutes: 60
     env:
       VAR_COS_BUCKET_CI: ${{ secrets.VAR_COS_BUCKET_CI }}


### PR DESCRIPTION
Signed-off-by: spacewander <spacewanderlzx@gmail.com>