### PR TITLE
fix: OPENRESTY_PREFIX=xxx no such file or directory

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -158,20 +158,21 @@ make -j`nproc`
 sudo make install
 cd ..
 
+OPENRESTY_PREFIX=$OR_PREFIX
 cd apisix-nginx-module-${apisix_nginx_module_ver} || exit 1
-sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
+sudo make install
 cd ..
 
 cd wasm-nginx-module-${wasm_nginx_module_ver} || exit 1
-sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
+sudo make install
 cd ..
 
 cd grpc-client-nginx-module-${grpc_client_nginx_module_ver} || exit 1
-sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
+sudo make install
 cd ..
 
 cd amesh-${amesh_ver} || exit 1
-sudo OPENRESTY_PREFIX="$OR_PREFIX" sh -c 'PATH="${PATH}:/usr/local/go/bin" make install'
+sudo sh -c 'PATH="${PATH}:/usr/local/go/bin" make install'
 cd ..
 
 # package etcdctl


### PR DESCRIPTION
When use `sudo OPENRESTY_PREFIX=xxx`, the terminal will print 'OPENRESTY_PREFIX=xxx: no such file or directory' on CentOS7's bash.

Signed-off-by: Wenyu Huang <huangwenyuu@outlook.com>