### PR TITLE
fix: Increase timeout for publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
   publish_apisix:
     name: Build and Publish RPM Package
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 100
     env:
       VAR_COS_BUCKET_CI: ${{ secrets.VAR_COS_BUCKET_CI }}
       VAR_COS_BUCKET_REPO: ${{ secrets.VAR_COS_BUCKET_REPO }}


### PR DESCRIPTION
Currently this[1] github action is failing due to timeout. This PR increases the timeout to fix it. 

1. https://github.com/api7/apisix-build-tools/actions/runs/5025121515