### PR TITLE
add ipv6 parameter

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -171,6 +171,7 @@ fi
     --with-threads \
     --with-compat \
     --with-luajit-xcflags="$luajit_xcflags" \
+    --with-ipv6 \
     $no_pool_patch \
     -j`nproc`
 


### PR DESCRIPTION
this [issue](https://github.com/api7/apisix-build-tools/issues/305)
I found cannot support etcd ipv6 address, so update the build parameter