### PR TITLE
fix(ci): apisix should rely on apisix-base instead of openresty

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -51,7 +51,7 @@ jobs:
           echo build ${TAG_TYPE} deb package
           echo version ${TAG_VERSION}
 
-          make package type=deb app=${TAG_TYPE} checkout=${TAG_VERSION} version=${TAG_VERSION} image_base=${VAR_OS} image_tag=${VAR_OS_RELEASE}
+          make package type=deb app=${TAG_TYPE} checkout=${TAG_VERSION} version=${TAG_VERSION} image_base=${VAR_OS} image_tag=${VAR_OS_RELEASE} openresty=apisix-base
           mv ./output/${TAG_TYPE}_${TAG_VERSION}-0~${VAR_OS}${VAR_OS_RELEASE}_amd64.deb ${VAR_DEB_WORKBENCH_DIR}
 
       - name: Upload apisix/apisix-base Artifact


### PR DESCRIPTION
3.5.0 deb
```yaml
Package: apisix
Version: 3.5.0-0
License: ASL 2.0
Vendor: none
Architecture: amd64
Maintainer: <@buildkitsandbox>
Installed-Size: 14342
Depends: openresty (>= 1.19.3.2), openresty (<< 1.21.5), libldap2-dev, libpcre3, debianutils
Section: default
Priority: optional
Homepage: http://apisix.apache.org/
Description: Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.
```
