### PR TITLE
chore: update base image version

### DIFF
--- a/dockerfiles/Dockerfile.apisix-base.deb
+++ b/dockerfiles/Dockerfile.apisix-base.deb
@@ -1,5 +1,5 @@
 ARG IMAGE_BASE="debian"
-ARG IMAGE_TAG="bullseye-slim"
+ARG IMAGE_TAG="bookworm-slim"
 
 FROM ${IMAGE_BASE}:${IMAGE_TAG} as build
 


### PR DESCRIPTION
The existing image has a vulnerability: https://hub.docker.com/layers/library/debian/bullseye-slim/images/sha256-bb9ee60a865c4276e72b33b04c7892d4011e730d1e865d931537082e895bc385?context=repo&tab=vulnerabilities