### PR TITLE
chore: remove etcdctl

### DIFF
--- a/.github/workflows/package-apisix-base-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-base-deb-ubuntu20.04.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: check and ensure apisix-base is installed
         run: |
-          docker exec ubuntu20.04Instance bash -c "/usr/local/openresty/bin/etcdctl -h" || exit 1
           export APISIX_BASE_VER=$(docker exec ubuntu20.04Instance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_BASE_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_BASE_VER" != "${BUILD_APISIX_BASE_VERSION}" ]; then exit 1; fi
 

--- a/.github/workflows/package-apisix-base-rpm-el7.yml
+++ b/.github/workflows/package-apisix-base-rpm-el7.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: check and ensure apisix-base is installed
         run: |
-          docker exec centos7Instance bash -c "/usr/local/openresty/bin/etcdctl -h" || exit 1
           export APISIX_BASE_VER=$(docker exec centos7Instance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_BASE_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_BASE_VER" != "${BUILD_APISIX_BASE_VERSION}" ]; then exit 1; fi
 

--- a/.github/workflows/package-apisix-base-rpm-el8.yml
+++ b/.github/workflows/package-apisix-base-rpm-el8.yml
@@ -53,7 +53,6 @@ jobs:
 
       - name: check and ensure apisix-base is installed
         run: |
-          docker exec centos8Instance bash -c "/usr/local/openresty/bin/etcdctl -h" || exit 1
           export APISIX_BASE_VER=$(docker exec centos8Instance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_BASE_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_BASE_VER" != "${BUILD_APISIX_BASE_VERSION}" ]; then exit 1; fi
 

--- a/.github/workflows/package-apisix-base-rpm-ubi.yml
+++ b/.github/workflows/package-apisix-base-rpm-ubi.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: check and ensure apisix-base is installed
         run: |
-          docker exec ubiInstance bash -c "/usr/local/openresty/bin/etcdctl -h" || exit 1
           export APISIX_BASE_VER=$(docker exec ubiInstance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_BASE_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_BASE_VER" != "${BUILD_APISIX_BASE_VERSION}" ]; then exit 1; fi
 

--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -185,18 +185,3 @@ cd ..
 cd grpc-client-nginx-module-${grpc_client_nginx_module_ver} || exit 1
 sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
-
-# package etcdctl
-ETCD_ARCH="amd64"
-ETCD_VERSION=${ETCD_VERSION:-'3.5.4'}
-ARCH=${ARCH:-$(uname -m | tr '[:upper:]' '[:lower:]')}
-
-if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
-    ETCD_ARCH="arm64"
-fi
-
-wget -q https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz
-tar xf etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz
-# ship etcdctl under the same bin dir of openresty so we can package it easily
-sudo cp etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}/etcdctl "$OR_PREFIX"/bin/
-rm -rf etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}


### PR DESCRIPTION
This PR: https://github.com/apache/apisix/pull/10015 removes the usage of `etcdctl` from APISIX due to this it's unnecessary to package `etcdctl` into apisix-base.