### PR TITLE
fix: apisix startup failed due to unix socket not being removed

### DIFF
--- a/usr/lib/systemd/system/apisix.service
+++ b/usr/lib/systemd/system/apisix.service
@@ -10,6 +10,7 @@ Wants=network-online.target
 Type=forking
 Restart=on-failure
 WorkingDirectory=/usr/local/apisix
+ExecStartPre=/bin/rm -f /usr/local/apisix/logs/worker_events.sock
 ExecStart=/usr/bin/apisix start
 ExecStop=/usr/bin/apisix stop
 ExecReload=/usr/bin/apisix reload


### PR DESCRIPTION
ref: https://github.com/apache/apisix/pull/10732

The files being exposed by container mounts and not being cleaned up on abnormal exits resulting in failure to start next time.