### PR TITLE
fix: remove grpc-client-nginx-module

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -15,7 +15,6 @@ if ([ $# -gt 0 ] && [ "$1" == "latest" ]) || [ "$version" == "latest" ]; then
     apisix_nginx_module_ver="main"
     wasm_nginx_module_ver="main"
     lua_var_nginx_module_ver="master"
-    grpc_client_nginx_module_ver="main"
     lua_resty_events_ver="main"
     debug_args="--with-debug"
     OR_PREFIX=${OR_PREFIX:="/usr/local/openresty-debug"}
@@ -25,7 +24,6 @@ else
     apisix_nginx_module_ver="1.15.0"
     wasm_nginx_module_ver="0.6.5"
     lua_var_nginx_module_ver="v0.5.3"
-    grpc_client_nginx_module_ver="v0.4.4"
     lua_resty_events_ver="0.2.0"
     debug_args=${debug_args:-}
     OR_PREFIX=${OR_PREFIX:="/usr/local/openresty"}
@@ -79,14 +77,6 @@ else
         lua-var-nginx-module-${lua_var_nginx_module_ver}
 fi
 
-if [ "$repo" == grpc-client-nginx-module ]; then
-    cp -r "$prev_workdir" ./grpc-client-nginx-module-${grpc_client_nginx_module_ver}
-else
-    git clone --depth=1 -b $grpc_client_nginx_module_ver \
-        https://github.com/api7/grpc-client-nginx-module \
-        grpc-client-nginx-module-${grpc_client_nginx_module_ver}
-fi
-
 if [ "$repo" == lua-resty-events ]; then
     cp -r "$prev_workdir" ./lua-resty-events-${lua_resty_events_ver}
 else
@@ -112,8 +102,6 @@ ld_opt=${ld_opt:-}
 luajit_xcflags=${luajit_xcflags:="-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT"}
 no_pool_patch=${no_pool_patch:-}
 # TODO: remove old NGX_HTTP_GRPC_CLI_ENGINE_PATH once we have released a new
-# version of grpc-client-nginx-module
-grpc_engine_path="-DNGX_GRPC_CLI_ENGINE_PATH=$OR_PREFIX/libgrpc_engine.so -DNGX_HTTP_GRPC_CLI_ENGINE_PATH=$OR_PREFIX/libgrpc_engine.so"
 
 cd openresty-${OPENRESTY_VERSION} || exit 1
 
@@ -139,7 +127,7 @@ else
 fi
 
 ./configure --prefix="$OR_PREFIX" \
-    --with-cc-opt="-DAPISIX_BASE_VER=$version $grpc_engine_path $cc_opt" \
+    --with-cc-opt="-DAPISIX_BASE_VER=$version $cc_opt" \
     --with-ld-opt="-Wl,-rpath,$OR_PREFIX/wasmtime-c-api/lib $ld_opt" \
     $debug_args \
     --add-module=../mod_dubbo-${mod_dubbo_ver} \
@@ -149,7 +137,6 @@ fi
     --add-module=../apisix-nginx-module-${apisix_nginx_module_ver}/src/meta \
     --add-module=../wasm-nginx-module-${wasm_nginx_module_ver} \
     --add-module=../lua-var-nginx-module-${lua_var_nginx_module_ver} \
-    --add-module=../grpc-client-nginx-module-${grpc_client_nginx_module_ver} \
     --add-module=../lua-resty-events-${lua_resty_events_ver} \
     --with-poll_module \
     --with-pcre-jit \
@@ -190,10 +177,6 @@ sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
 
 cd wasm-nginx-module-${wasm_nginx_module_ver} || exit 1
-sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
-cd ..
-
-cd grpc-client-nginx-module-${grpc_client_nginx_module_ver} || exit 1
 sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
 

--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -101,7 +101,6 @@ cc_opt=${cc_opt:-}
 ld_opt=${ld_opt:-}
 luajit_xcflags=${luajit_xcflags:="-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT"}
 no_pool_patch=${no_pool_patch:-}
-# TODO: remove old NGX_HTTP_GRPC_CLI_ENGINE_PATH once we have released a new
 
 cd openresty-${OPENRESTY_VERSION} || exit 1
 

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -27,7 +27,6 @@ mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver="1.15.0"
 wasm_nginx_module_ver="0.6.5"
 lua_var_nginx_module_ver="v0.5.3"
-grpc_client_nginx_module_ver="v0.4.4"
 lua_resty_events_ver="0.2.0"
 
 
@@ -128,14 +127,6 @@ else
         lua-var-nginx-module-${lua_var_nginx_module_ver}
 fi
 
-if [ "$repo" == grpc-client-nginx-module ]; then
-    cp -r "$prev_workdir" ./grpc-client-nginx-module-${grpc_client_nginx_module_ver}
-else
-    git clone --depth=1 -b $grpc_client_nginx_module_ver \
-        https://github.com/api7/grpc-client-nginx-module \
-        grpc-client-nginx-module-${grpc_client_nginx_module_ver}
-fi
-
 cd ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} || exit 1
 ./patch.sh ../openresty-${OPENRESTY_VERSION}
 cd ..
@@ -152,8 +143,6 @@ cd ..
 luajit_xcflags=${luajit_xcflags:="-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT"}
 no_pool_patch=${no_pool_patch:-}
 # TODO: remove old NGX_HTTP_GRPC_CLI_ENGINE_PATH once we have released a new
-# version of grpc-client-nginx-module
-grpc_engine_path="-DNGX_GRPC_CLI_ENGINE_PATH=$OR_PREFIX/libgrpc_engine.so -DNGX_HTTP_GRPC_CLI_ENGINE_PATH=$OR_PREFIX/libgrpc_engine.so"
 
 cd openresty-${OPENRESTY_VERSION} || exit 1
 
@@ -171,7 +160,7 @@ fi
 
 
 ./configure --prefix="$OR_PREFIX" \
-    --with-cc-opt="-DAPISIX_RUNTIME_VER=$runtime_version $grpc_engine_path $cc_opt" \
+    --with-cc-opt="-DAPISIX_RUNTIME_VER=$runtime_version $cc_opt" \
     --with-ld-opt="-Wl,-rpath,$OR_PREFIX/wasmtime-c-api/lib $ld_opt" \
     $debug_args \
     --add-module=../mod_dubbo-${mod_dubbo_ver} \
@@ -181,7 +170,6 @@ fi
     --add-module=../apisix-nginx-module-${apisix_nginx_module_ver}/src/meta \
     --add-module=../wasm-nginx-module-${wasm_nginx_module_ver} \
     --add-module=../lua-var-nginx-module-${lua_var_nginx_module_ver} \
-    --add-module=../grpc-client-nginx-module-${grpc_client_nginx_module_ver} \
     --add-module=../lua-resty-events-${lua_resty_events_ver} \
     --with-poll_module \
     --with-pcre-jit \
@@ -229,10 +217,6 @@ sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
 
 cd wasm-nginx-module-${wasm_nginx_module_ver} || exit 1
-sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
-cd ..
-
-cd grpc-client-nginx-module-${grpc_client_nginx_module_ver} || exit 1
 sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
 

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -142,7 +142,6 @@ cd ..
 
 luajit_xcflags=${luajit_xcflags:="-DLUAJIT_NUMMODE=2 -DLUAJIT_ENABLE_LUA52COMPAT"}
 no_pool_patch=${no_pool_patch:-}
-# TODO: remove old NGX_HTTP_GRPC_CLI_ENGINE_PATH once we have released a new
 
 cd openresty-${OPENRESTY_VERSION} || exit 1
 


### PR DESCRIPTION
In APISIX, a Golang library was previously used to effectively implement a gRPC client and bind it to the Nginx ecosystem. It is called [grpc-client-nginx-module](https://github.com/api7/grpc-client-nginx-module). APISIX no longer uses this, it was removed in the PR https://github.com/apache/apisix/pull/9456. This PR removes it from the build-tools