### PR TITLE
fix: dashboard ci

### DIFF
--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -158,6 +158,7 @@ install_dashboard() {
     go env -w GOPROXY="${goproxy}"
     cd /tmp/
     cd /apisix-dashboard
+    npm config set strict-ssl false
     make build
     # copy the compiled files to the specified directory for packaging
     cp -r output/* /tmp/build/output/apisix/dashboard/usr/local/apisix/dashboard

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -158,7 +158,8 @@ install_dashboard() {
     go env -w GOPROXY="${goproxy}"
     cd /tmp/
     cd /apisix-dashboard
-    npm config set strict-ssl false
+    # FIXME: when the certificate is valid
+    yarn config set "strict-ssl" false -g
     make build
     # copy the compiled files to the specified directory for packaging
     cp -r output/* /tmp/build/output/apisix/dashboard/usr/local/apisix/dashboard


### PR DESCRIPTION
<img width="1236" alt="image" src="https://github.com/api7/apisix-build-tools/assets/25628854/2c0e8e33-48b6-47e0-9810-ca65892b889a">

As we can see in the picture, the CI will fail because of `error An unexpected error occurred: "https://registry.npm.taobao.org/state-local/download/state-local-1.0.7.tgz: certificate has expired".`
Now we don't have any method to let upstream update the `certificate`, so we can set `strict-ssl` to false to avoid verifying the certificate.