### PR TITLE
feat: Make sure that NGINX installation includes the HTTP and Stream Real‑IP modules.

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -145,6 +145,7 @@ fi
     --with-stream \
     --with-stream_ssl_module \
     --with-stream_ssl_preread_module \
+    --with-stream_realip_module \
     --with-http_v2_module \
     --with-http_v3_module \
     --without-mail_pop3_module \

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -178,6 +178,7 @@ fi
     --with-stream \
     --with-stream_ssl_module \
     --with-stream_ssl_preread_module \
+    --with-stream_realip_module \
     --with-http_v2_module \
     --with-http_v3_module \
     --without-mail_pop3_module \


### PR DESCRIPTION
### The stream_realip_module is added so that apisix can obtain the real client IP address of TCP requests forwarded by the load balancer in the layer 4 proxy.

> Reference: https://docs.nginx.com/nginx/admin-guide/load-balancer/using-proxy-protocol/#realip
![image](https://github.com/api7/apisix-build-tools/assets/65661595/f95f5f23-d115-4ec0-a2df-8af2e1fb28c1)
