### PR TITLE
ci: add manual trigger to build apisix-runtime debian package

### DIFF
--- a/.github/workflows/package-apisix-runtime-deb-ubuntu20.04-openresty-1.21.yml
+++ b/.github/workflows/package-apisix-runtime-deb-ubuntu20.04-openresty-1.21.yml
@@ -1,27 +1,18 @@
 name: package apisix-runtime deb for ubuntu 20.04(Focal Fossa)
 
 on:
-  push:
-    branches: [ master ]
-    tags:
-      - "v*"
-    paths-ignore:
-      - '*.md'
-  pull_request:
-    branches: [ master ]
-    paths-ignore:
-      - '*.md'
-  schedule:
-    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      BUILD_APISIX_RUNTIME_VERSION: 1.0.1
+      BUILD_APISIX_RUNTIME_VERSION: 1.1.2
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: openresty/1.21.4
 
       - name: install dependencies
         run: |

--- a/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
@@ -13,15 +13,25 @@ on:
       - '*.md'
   schedule:
     - cron: '0 0 * * *'
-
+  workflow_dispatch: # Allows the workflow to be triggered manually
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on' 
+        required: true
+        default: 'master'
+      apisix-runtime-version:
+        description: 'apisix-runtime version to build'
+        required: false
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      BUILD_APISIX_RUNTIME_VERSION: 1.0.1
+      BUILD_APISIX_RUNTIME_VERSION: ${{ github.event.inputs.apisix-runtime-version || '1.0.1' }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: install dependencies
         run: |
@@ -48,7 +58,7 @@ jobs:
       - name: Publish Artifact
         uses: actions/upload-artifact@v4.0.0
         with:
-          name: apisix-runtime_${{ env.BUILD_APISIX_RUNTIME_VERSION }}-0~ubuntu20.04_amd64.deb
-          path: output/apisix-runtime_${{ env.BUILD_APISIX_RUNTIME_VERSION }}-0~ubuntu20.04_amd64.deb
+          name: apisix-runtime_${BUILD_APISIX_RUNTIME_VERSION}-0~ubuntu20.04_amd64.deb
+          path: output/apisix-runtime_${BUILD_APISIX_RUNTIME_VERSION}-0~ubuntu20.04_amd64.deb
           retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Publish Artifact
         uses: actions/upload-artifact@v4.0.0
         with:
-          name: apisix-runtime_${BUILD_APISIX_RUNTIME_VERSION}-0~ubuntu20.04_amd64.deb
-          path: output/apisix-runtime_${BUILD_APISIX_RUNTIME_VERSION}-0~ubuntu20.04_amd64.deb
+          name: apisix-runtime_${{ env.BUILD_APISIX_RUNTIME_VERSION }}-0~ubuntu20.04_amd64.deb
+          path: output/apisix-runtime_${{ env.BUILD_APISIX_RUNTIME_VERSION }}-0~ubuntu20.04_amd64.deb
           retention-days: 5
           if-no-files-found: error

--- a/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
@@ -29,6 +29,8 @@ jobs:
     env:
       BUILD_APISIX_RUNTIME_VERSION: ${{ github.event.inputs.apisix-runtime-version || '1.0.1' }}
     steps:
+      - name: print github.ref_name
+        run: echo ${{ github.ref_name }}
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.branch || github.ref_name }}


### PR DESCRIPTION
Currently the CI only runs on master branch and therefore builds the apisix debian package with Openresty Version 1.25 and Openssl version 3.2. 
This PR helps so that  in the case we want to build the debian package for apisix-runtime where the apisix runtime uses openresty/1.21 we can manually trigger it on a branch we already have openresty/1.21 where the script it uses builds the apisix-runtime with Openresty 1.21 and Openssl 3.2