### PR TITLE
ci: install missing dependency to build image(openresty/1.21.4 branch)

### DIFF
--- a/dockerfiles/Dockerfile.fpm
+++ b/dockerfiles/Dockerfile.fpm
@@ -3,6 +3,7 @@ FROM ubuntu:focal
 RUN DEBIAN_FRONTEND=noninteractive apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y git \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ruby ruby-dev rubygems build-essential rpm \
+    && gem install dotenv -v 2.8.1 \
     && gem install fpm \
     && fpm --version
 


### PR DESCRIPTION
This dependency is present in master branch and building it in openresty/1.21.4 branch results in error
https://github.com/api7/apisix-build-tools/blob/92d40ebda2d047ed51db6c1cb41f44410d98e319/dockerfiles/Dockerfile.fpm#L6C5-L6C37