### PR TITLE
upgrade: luajit to version 2.1-20240815

### DIFF
--- a/build-api7ee-runtime.sh
+++ b/build-api7ee-runtime.sh
@@ -158,6 +158,15 @@ grpc_engine_path="-DNGX_GRPC_CLI_ENGINE_PATH=$OR_PREFIX/libgrpc_engine.so -DNGX_
 
 cd openresty-${OPENRESTY_VERSION} || exit 1
 
+if [[ "$OPENRESTY_VERSION" == 1.21.4.4 ]] ; then
+    # upgrade luajit
+    rm -rf bundle/LuaJIT-2.1-20230410.1
+    lj_ver=2.1-20240815
+    wget "https://github.com/openresty/luajit2/archive/v$lj_ver.tar.gz" -O "LuaJIT-$lj_ver.tar.gz"
+    tar -xzf LuaJIT-$lj_ver.tar.gz
+    mv luajit2-* bundle/LuaJIT-2.1-20230410.1
+fi
+
 or_limit_ver=0.08
 if [ ! -d "bundle/lua-resty-limit-traffic-$or_limit_ver" ]; then
     echo "ERROR: the official repository of lua-resty-limit-traffic has been updated, please sync to API7's repository." >&2

--- a/build-api7ee-runtime.sh
+++ b/build-api7ee-runtime.sh
@@ -164,7 +164,7 @@ if [[ "$OPENRESTY_VERSION" == 1.21.4.4 ]] ; then
     lj_ver=2.1-20240815
     wget "https://github.com/openresty/luajit2/archive/v$lj_ver.tar.gz" -O "LuaJIT-$lj_ver.tar.gz"
     tar -xzf LuaJIT-$lj_ver.tar.gz
-    mv luajit2-* bundle/
+    mv luajit2-* bundle/LuaJIT-$lj_ver
 fi
 
 or_limit_ver=0.08

--- a/build-api7ee-runtime.sh
+++ b/build-api7ee-runtime.sh
@@ -164,7 +164,7 @@ if [[ "$OPENRESTY_VERSION" == 1.21.4.4 ]] ; then
     lj_ver=2.1-20240815
     wget "https://github.com/openresty/luajit2/archive/v$lj_ver.tar.gz" -O "LuaJIT-$lj_ver.tar.gz"
     tar -xzf LuaJIT-$lj_ver.tar.gz
-    mv luajit2-* bundle/LuaJIT-2.1-20230410.1
+    mv luajit2-* bundle/
 fi
 
 or_limit_ver=0.08


### PR DESCRIPTION
`In LuaJit version 2.1-20240815, some performance and security issues have been fixed. OpenResty version 1.27.1.1 has already used this version, and we hope that the enterprise version will also be upgraded to this version.`

LuaJIT updated to 2.1-20240815 with various optimizations and bugfixes:

```
Improved error handling and stack overflow management

Enhanced cross-32/64 bit and deterministic bytecode generation

Disabled hash computation optimization in the OpenResty branch due to potential severe performance degradation (CVE-2024-39702). This issue only exists in the OpenResty branch (agentzh-v2.1) and not in upstream LuaJIT. We thank Zhongwei Yao from Kong Inc. for reporting this issue.

```