### PR TITLE
deps: upgrade openssl to 3.4.1

### DIFF
--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -37,7 +37,7 @@ install_openssl_3(){
     fi
     # required for openssl 3.x config
     cpanm IPC/Cmd.pm
-    wget --no-check-certificate https://github.com/openssl/openssl/releases/download/openssl-3.2.0/openssl-${OPENSSL_VERSION}.tar.gz
+    wget --no-check-certificate https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz
     tar xvf openssl-${OPENSSL_VERSION}.tar.gz
     cd openssl-${OPENSSL_VERSION}/
     export LDFLAGS="-Wl,-rpath,$zlib_prefix/lib:$OPENSSL_PREFIX/lib"


### PR DESCRIPTION
use same openssl version with latest release of openresty:
https://github.com/openresty/openresty/blob/177ba250ccc748a8b644fe300a14d4ece477010e/.travis.yml#L50