### PR TITLE
feat: add api7ee-runtime-debug package to release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,19 @@ jobs:
       - name: Build api7ee-runtime deb
         run: |
           make package type=deb app=api7ee-runtime runtime_version=${version} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }}
+
+      - name: Build api7ee-runtime-debug deb
+        run: |
+          make package type=deb app=api7ee-runtime runtime_version=${version} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }} build_latest=latest artifact=api7ee-runtime-debug
       
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: api7ee-runtime_${{ env.version }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
           path: ./output/api7ee-runtime_${{ env.version }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
+
+      - name: Upload Debug Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api7ee-runtime-debug_${{ env.version }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
+          path: ./output/api7ee-runtime-debug_${{ env.version }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - release/api7ee-runtime
     paths:
       - VERSION
+  workflow_dispatch:
 
 jobs:
   release:
@@ -41,6 +42,10 @@ jobs:
         run: |
           make package type=deb app=api7ee-runtime runtime_version=${version} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }}
 
+      - name: Build api7ee-runtime-debug deb
+        run: |
+          make package type=deb app=api7ee-runtime runtime_version=${version} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }} build_latest=latest artifact=api7ee-runtime-debug
+
       - uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
         with: 
@@ -65,5 +70,6 @@ jobs:
             Release api7ee-runtime ${{ env.version }}
           files: |
             ./output/api7ee-runtime_${{ env.version }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
+            ./output/api7ee-runtime-debug_${{ env.version }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ iteration=0
 local_code_path=0
 openresty="api7ee-runtime"
 artifact="0"
+build_latest=
 runtime_version="0"
 apisix_repo="https://github.com/apache/apisix"
 apisix_runtime_repo="https://github.com/api7/apisix-build-tools.git"
@@ -89,6 +90,7 @@ define build_runtime
 		--build-arg RUNTIME_VERSION=$(runtime_version) \
 		--build-arg IMAGE_BASE=$(image_base) \
 		--build-arg IMAGE_TAG=$(image_tag) \
+		--build-arg BUILD_LATEST=$(build_latest) \
 		--build-arg CODE_PATH=$(4) \
     --platform $(arch) \
 		-f ./dockerfiles/Dockerfile.$(2).$(3) .
@@ -101,6 +103,7 @@ define build_runtime
 		--build-arg RUNTIME_VERSION=$(runtime_version) \
 		--build-arg IMAGE_BASE=$(image_base) \
 		--build-arg IMAGE_TAG=$(image_tag) \
+		--build-arg BUILD_LATEST=$(build_latest) \
 		--build-arg CODE_PATH=$(4) \
 		--load \
 		--cache-from=$(cache_from) \

--- a/package-api7ee-runtime.sh
+++ b/package-api7ee-runtime.sh
@@ -45,5 +45,5 @@ fi
 
 if [ "$PACKAGE_TYPE" == "deb" ]; then
     # Rename deb file with adding $DIST section
-    mv /output/api7ee-runtime_"${RUNTIME_VERSION}"-"${ITERATION}"_"${PACKAGE_ARCH}".deb /output/api7ee-runtime_"${RUNTIME_VERSION}"-"${ITERATION}"~"${dist}"_"${PACKAGE_ARCH}".deb
+    mv /output/"${artifact}"_"${RUNTIME_VERSION}"-"${ITERATION}"_"${PACKAGE_ARCH}".deb /output/"${artifact}"_"${RUNTIME_VERSION}"-"${ITERATION}"~"${dist}"_"${PACKAGE_ARCH}".deb
 fi


### PR DESCRIPTION
## What

Add support for building a **debug** variant of api7ee-runtime (compiled with `--with-debug`) alongside the regular release package.

## Why

Gateway CI compiles OpenResty from source with `--with-debug` on every run. This:
1. **Depends on the openresty.org apt repo** for `openresty-pcre-dev` and `openresty-zlib-dev` — when the repo is down, all CI fails
2. **Takes ~10 minutes** per CI run for source compilation

By publishing a pre-built debug `.deb`, gateway CI can simply download and install it.

## Changes

- **Makefile**: Add `build_latest` variable, pass `BUILD_LATEST` arg to `build_runtime` function
- **package-api7ee-runtime.sh**: Use `$artifact` variable in deb rename (was hardcoded to `api7ee-runtime`)
- **release.yml**: Add `workflow_dispatch` trigger; add debug package build & upload steps
- **build.yml**: Add debug build step and artifact upload for CI testing

## Usage

```bash
# Build debug package
make package type=deb app=api7ee-runtime runtime_version=1.2.8 \
  image_base=debian image_tag=bookworm-slim build_latest=latest artifact=api7ee-runtime-debug
```

After merge, use `workflow_dispatch` to trigger the release workflow and publish debug packages for the current version (1.2.8).

Closes api7/api7-ee-3-gateway#1289