### PR TITLE
fix: replace openresty apt repo with system pcre/zlib packages

### DIFF
--- a/utils/build-common.sh
+++ b/utils/build-common.sh
@@ -12,19 +12,17 @@ build_api7ee_runtime_deb() {
     fi
     DEBIAN_FRONTEND=noninteractive apt-get update --fix-missing
     DEBIAN_FRONTEND=noninteractive apt-get install -y sudo git libreadline-dev lsb-release libssl-dev perl build-essential gcc g++ xz-utils curl cpanminus
-    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates 
-    wget -O - https://openresty.org/package/pubkey.gpg | apt-key add -
-
-    if [[ $IMAGE_BASE == "ubuntu" ]]; then
-        echo "deb http://openresty.org/package/${arch_path}ubuntu $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/openresty.list
-    fi
-
-    if [[ $IMAGE_BASE == "debian" ]]; then
-        echo "deb http://openresty.org/package/${arch_path}debian $(lsb_release -sc) openresty" | tee /etc/apt/sources.list.d/openresty.list
-    fi
-
-    DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y openresty-pcre-dev openresty-zlib-dev
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
+    # Use system pcre/zlib dev packages instead of openresty apt repo packages
+    # to avoid dependency on the unreliable openresty.org apt repository.
+    # Symlink them into the paths expected by the build scripts.
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libpcre3-dev zlib1g-dev
+    MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+    mkdir -p /usr/local/openresty/pcre /usr/local/openresty/zlib
+    ln -sf /usr/include /usr/local/openresty/pcre/include
+    ln -sf /usr/lib/${MULTIARCH} /usr/local/openresty/pcre/lib
+    ln -sf /usr/include /usr/local/openresty/zlib/include
+    ln -sf /usr/lib/${MULTIARCH} /usr/local/openresty/zlib/lib
 
     export_openresty_variables
     # fix OR_PREFIX


### PR DESCRIPTION
## What

Replace `openresty-pcre-dev` and `openresty-zlib-dev` (from the openresty.org apt repository) with system `libpcre3-dev` and `zlib1g-dev` packages in the Docker build.

## Why

The openresty.org apt repository is unreliable. The release workflow just failed with:
```
E: Failed to fetch http://openresty.org/package/debian/dists/bookworm/openresty/binary-amd64/Packages.gz
File has unexpected size (35698 != 33713). Mirror sync in progress?
```

This blocks both the runtime release packaging and the gateway CI from passing.

## How

Install system `libpcre3-dev` and `zlib1g-dev`, then create symlinks from the expected openresty paths (`/usr/local/openresty/{pcre,zlib}/`) to the system include/lib directories. This is a drop-in replacement that requires no changes to `build-api7ee-runtime.sh` or `export_openresty_variables`.

## Urgency

This is blocking the release of the debug package (from #450) which in turn blocks the gateway CI fix (api7/api7-ee-3-gateway#1291).