### PR TITLE
chore: replace bullseye with bookworm

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -22,7 +22,7 @@ jobs:
             arch: arm64
         target:
           - os: debian
-            codename: bookworm
+            codename: debian12
             release: bookworm-slim
           - os: ubuntu
             codename: noble

--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -22,8 +22,8 @@ jobs:
             arch: arm64
         target:
           - os: debian
-            codename: bullseye
-            release: bullseye-slim
+            codename: bookworm
+            release: bookworm-slim
           - os: ubuntu
             codename: noble
             release: 24.04


### PR DESCRIPTION
## Summary

- Add `debian/bookworm` target to the `publish-deb.yml` CI matrix alongside the existing `ubuntu/noble` target
- Remove the `debian/bullseye` target as Debian 11 reaches EOL in June 2026

## Why

The [apisix-docker](https://github.com/apache/apisix-docker) repo is upgrading its Debian base image from `bullseye-slim` to `bookworm-slim` ([PR #618](https://github.com/apache/apisix-docker/pull/618)). This is needed because:

1. **QEMU/ldconfig segfault**: During arm64 Docker image builds (emulated via QEMU on amd64 CI runners), `ldconfig` from Debian 11's glibc segfaults under QEMU user-mode emulation. Debian 12's glibc does not hit this bug.
2. **Debian 11 EOL**: bullseye reaches end-of-life in June 2026.

However, `repos.apiseven.com` currently only publishes APISIX packages for the `bullseye` codename.
When the Docker build tries `apt-get install apisix` on a `bookworm-slim` base, it gets a 404:

```text
Err: https://repos.apiseven.com/packages/debian bookworm Release
  404  Not Found
```

This PR adds `bookworm` to the publish matrix so that future APISIX releases produce packages for Debian 12 on both amd64 and arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Debian build target configuration to use Bookworm (Debian 12) instead of Bullseye.
  * Adjusted related release image selection; no other workflow logic, steps, conditions, or artifact names were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->