### PR TITLE
deps: upgrade lua-resty-limit-traffic from 1.0.0 to 1.2.0

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -119,7 +119,7 @@ if [ ! -d "bundle/lua-resty-limit-traffic-$or_limit_ver" ]; then
     exit 1
 else
     rm -rf bundle/lua-resty-limit-traffic-$or_limit_ver
-    limit_ver=1.0.0
+    limit_ver=1.2.0
     wget "https://github.com/api7/lua-resty-limit-traffic/archive/refs/tags/v$limit_ver.tar.gz" -O "lua-resty-limit-traffic-$limit_ver.tar.gz"
     tar -xzf lua-resty-limit-traffic-$limit_ver.tar.gz
     mv lua-resty-limit-traffic-$limit_ver bundle/lua-resty-limit-traffic-$or_limit_ver

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -151,7 +151,7 @@ if [ ! -d "bundle/lua-resty-limit-traffic-$or_limit_ver" ]; then
     exit 1
 else
     rm -rf bundle/lua-resty-limit-traffic-$or_limit_ver
-    limit_ver=1.0.0
+    limit_ver=1.2.0
     wget "https://github.com/api7/lua-resty-limit-traffic/archive/refs/tags/v$limit_ver.tar.gz" -O "lua-resty-limit-traffic-$limit_ver.tar.gz"
     tar -xzf lua-resty-limit-traffic-$limit_ver.tar.gz
     mv lua-resty-limit-traffic-$limit_ver bundle/lua-resty-limit-traffic-$or_limit_ver


### PR DESCRIPTION
### Description

Upgrade `lua-resty-limit-traffic` from v1.0.0 to v1.2.0 in both `build-apisix-runtime.sh` and `build-apisix-base.sh`.

### Why

This aligns the open-source `apisix-runtime` and `apisix-base` with the enterprise `api7ee-runtime`, which already uses v1.2.0.

Key library change in v1.2.0: `incoming_new()` counts UP from 0 (returns consumed count) instead of DOWN from limit (returns remaining count), and removes the `assert(cost >= 1)` restriction.

The companion APISIX PR ([apache/apisix#13191](https://github.com/apache/apisix/pull/13191)) adapts `limit-count-local.lua` to handle the new return value semantics (consumed → remaining conversion).

### Changes

- `build-apisix-runtime.sh`: `limit_ver=1.0.0` → `limit_ver=1.2.0`
- `build-apisix-base.sh`: `limit_ver=1.0.0` → `limit_ver=1.2.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled traffic-limiting dependency from v1.0.0 to v1.2.0 so builds include the newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->