### PR TITLE
feat: upgrade OpenResty to 1.29.2.3

### DIFF
--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -4,9 +4,9 @@ set -x
 
 version=${version:-0.0.0}
 
-OPENRESTY_VERSION=${OPENRESTY_VERSION:-1.27.1.2}
+OPENRESTY_VERSION=${OPENRESTY_VERSION:-1.29.2.3}
 if [ "$OPENRESTY_VERSION" == "source" ] || [ "$OPENRESTY_VERSION" == "default" ]; then
-    OPENRESTY_VERSION="1.27.1.2"
+    OPENRESTY_VERSION="1.29.2.3"
 fi
 
 if ([ $# -gt 0 ] && [ "$1" == "latest" ]) || [ "$version" == "latest" ]; then

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -21,7 +21,7 @@ ld_opt=${ld_opt:-"-L$zlib_prefix/lib -L$pcre_prefix/lib -L$OPENSSL_PREFIX/lib -W
 
 # dependencies for building openresty
 OPENSSL_VERSION=${OPENSSL_VERSION:-"3.4.1"}
-OPENRESTY_VERSION="1.27.1.2"
+OPENRESTY_VERSION="1.29.2.3"
 ngx_multi_upstream_module_ver="1.3.2"
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver="1.19.3"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded OpenResty runtime dependency to version 1.29.2.3 in build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->