### PR TITLE
feat: upgrade apisix-runtime to OpenResty 1.29.2.4

### DIFF
--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -27,14 +27,12 @@ if [[ ! "$OPENRESTY_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
     exit 1
 fi
 ngx_multi_upstream_module_ver="1.3.3"
-ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-""}
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"1.19.5"}
 if [[ ! "$apisix_nginx_module_ver" =~ ^[A-Za-z0-9._/-]+$ ]]; then
     echo "ERROR: invalid apisix_nginx_module_ver: $apisix_nginx_module_ver" >&2
     exit 1
 fi
-apisix_nginx_module_commit=${apisix_nginx_module_commit:-""}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"
@@ -73,29 +71,6 @@ install_openssl_3(){
     cd ..
 }
 
-verify_module_commit() {
-    local module_dir=$1
-    local expected_commit=$2
-    local current_commit
-
-    if ! git -C "$module_dir" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-        echo "ERROR: $module_dir is not a git worktree; cannot verify pinned commit ($expected_commit)" >&2
-        exit 1
-    fi
-
-    current_commit=$(git -C "$module_dir" rev-parse HEAD)
-    if [ "$current_commit" != "$expected_commit" ]; then
-        echo "ERROR: $module_dir HEAD ($current_commit) does not match pinned commit ($expected_commit)" >&2
-        exit 1
-    fi
-
-    if [ -n "$(git -C "$module_dir" status --porcelain --untracked-files=all)" ]; then
-        echo "ERROR: $module_dir has uncommitted changes; cannot verify pinned commit ($expected_commit)" >&2
-        exit 1
-    fi
-}
-
-
 if ([ $# -gt 0 ] && [ "$1" == "latest" ]) || [ "$runtime_version" == "0.0.0" ]; then
     debug_args="--with-debug"
 fi
@@ -120,23 +95,11 @@ else
 fi
 
 if [ "$repo" == ngx_multi_upstream_module ]; then
-    ngx_multi_upstream_module_cloned=0
     cp -r "$prev_workdir" ./ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}
 else
-    ngx_multi_upstream_module_cloned=1
-    ngx_multi_upstream_module_clone_ref="$ngx_multi_upstream_module_ver"
-    git clone --depth=1 -b $ngx_multi_upstream_module_clone_ref \
+    git clone --depth=1 -b $ngx_multi_upstream_module_ver \
         https://github.com/api7/ngx_multi_upstream_module.git \
         ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}
-fi
-if [ -n "$ngx_multi_upstream_module_commit" ] && [ "$ngx_multi_upstream_module_cloned" = 1 ]; then
-    git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} fetch --depth=1 \
-        origin "$ngx_multi_upstream_module_commit"
-    git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} checkout \
-        "$ngx_multi_upstream_module_commit"
-elif [ -n "$ngx_multi_upstream_module_commit" ]; then
-    verify_module_commit "ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}" \
-        "$ngx_multi_upstream_module_commit"
 fi
 
 if [ "$repo" == mod_dubbo ]; then
@@ -148,23 +111,11 @@ else
 fi
 
 if [ "$repo" == apisix-nginx-module ]; then
-    apisix_nginx_module_cloned=0
     cp -r "$prev_workdir" "./apisix-nginx-module-${apisix_nginx_module_ver}"
 else
-    apisix_nginx_module_cloned=1
-    apisix_nginx_module_clone_ref="$apisix_nginx_module_ver"
-    git clone --depth=1 -b "$apisix_nginx_module_clone_ref" -- \
+    git clone --depth=1 -b "$apisix_nginx_module_ver" -- \
         https://github.com/api7/apisix-nginx-module.git \
         "apisix-nginx-module-${apisix_nginx_module_ver}"
-fi
-if [ -n "$apisix_nginx_module_commit" ] && [ "$apisix_nginx_module_cloned" = 1 ]; then
-    git -C "apisix-nginx-module-${apisix_nginx_module_ver}" fetch --depth=1 \
-        origin "$apisix_nginx_module_commit"
-    git -C "apisix-nginx-module-${apisix_nginx_module_ver}" checkout \
-        "$apisix_nginx_module_commit"
-elif [ -n "$apisix_nginx_module_commit" ]; then
-    verify_module_commit "apisix-nginx-module-${apisix_nginx_module_ver}" \
-        "$apisix_nginx_module_commit"
 fi
 
 if [ "$repo" == wasm-nginx-module ]; then

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -27,7 +27,7 @@ ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
-apisix_nginx_module_commit=${apisix_nginx_module_commit:-"3a4ee4d120a0a4696efca115ec5ef254a16a5201"}
+apisix_nginx_module_commit=${apisix_nginx_module_commit:-"f2d67049784fd9d035ba02cea5fcd55eee313f9d"}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -27,7 +27,7 @@ ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
-apisix_nginx_module_commit=${apisix_nginx_module_commit:-"40492bca06153914d5084cfa92190c1dd7fd404e"}
+apisix_nginx_module_commit=${apisix_nginx_module_commit:-"3a4ee4d120a0a4696efca115ec5ef254a16a5201"}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -26,16 +26,15 @@ if [[ ! "$OPENRESTY_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
     echo "ERROR: invalid OPENRESTY_VERSION: $OPENRESTY_VERSION" >&2
     exit 1
 fi
-ngx_multi_upstream_module_ver="openresty-1.29.2-patches"
-ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a400165fa40d21288e4eea8952bbf89"}
+ngx_multi_upstream_module_ver="1.3.3"
+ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-""}
 mod_dubbo_ver="1.0.2"
-apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
+apisix_nginx_module_ver=${apisix_nginx_module_ver:-"1.19.5"}
 if [[ ! "$apisix_nginx_module_ver" =~ ^[A-Za-z0-9._/-]+$ ]]; then
     echo "ERROR: invalid apisix_nginx_module_ver: $apisix_nginx_module_ver" >&2
     exit 1
 fi
-# TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
-apisix_nginx_module_commit=${apisix_nginx_module_commit:-"c4b38ecbb54a47223112ba5d406f1dd392d44409"}
+apisix_nginx_module_commit=${apisix_nginx_module_commit:-""}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -23,11 +23,11 @@ ld_opt=${ld_opt:-"-L$zlib_prefix/lib -L$pcre_prefix/lib -L$OPENSSL_PREFIX/lib -W
 OPENSSL_VERSION=${OPENSSL_VERSION:-"3.4.1"}
 OPENRESTY_VERSION=${OPENRESTY_VERSION:-"1.29.2.4"}
 ngx_multi_upstream_module_ver="openresty-1.29.2-patches"
-ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit-"125e594a1a400165fa40d21288e4eea8952bbf89"}
+ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a400165fa40d21288e4eea8952bbf89"}
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
-apisix_nginx_module_commit=${apisix_nginx_module_commit-"36c6de78d74dd0f093e9a25910875762f6f56da6"}
+apisix_nginx_module_commit=${apisix_nginx_module_commit:-"36c6de78d74dd0f093e9a25910875762f6f56da6"}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"
@@ -96,9 +96,6 @@ if [ "$repo" == ngx_multi_upstream_module ]; then
 else
     ngx_multi_upstream_module_cloned=1
     ngx_multi_upstream_module_clone_ref="$ngx_multi_upstream_module_ver"
-    if [ -n "$ngx_multi_upstream_module_commit" ]; then
-        ngx_multi_upstream_module_clone_ref="master"
-    fi
     git clone --depth=1 -b $ngx_multi_upstream_module_clone_ref \
         https://github.com/api7/ngx_multi_upstream_module.git \
         ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}
@@ -130,9 +127,6 @@ if [ "$repo" == apisix-nginx-module ]; then
 else
     apisix_nginx_module_cloned=1
     apisix_nginx_module_clone_ref="$apisix_nginx_module_ver"
-    if [ -n "$apisix_nginx_module_commit" ]; then
-        apisix_nginx_module_clone_ref="main"
-    fi
     git clone --depth=1 -b $apisix_nginx_module_clone_ref \
         https://github.com/api7/apisix-nginx-module.git \
         apisix-nginx-module-${apisix_nginx_module_ver}

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -23,7 +23,7 @@ ld_opt=${ld_opt:-"-L$zlib_prefix/lib -L$pcre_prefix/lib -L$OPENSSL_PREFIX/lib -W
 OPENSSL_VERSION=${OPENSSL_VERSION:-"3.4.1"}
 OPENRESTY_VERSION=${OPENRESTY_VERSION:-"1.29.2.4"}
 ngx_multi_upstream_module_ver="openresty-1.29.2-patches"
-ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit-"0081acfacb2e79b7a5aa4f1f455316dd343e145f"}
+ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit-"125e594a1a400165fa40d21288e4eea8952bbf89"}
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -21,10 +21,13 @@ ld_opt=${ld_opt:-"-L$zlib_prefix/lib -L$pcre_prefix/lib -L$OPENSSL_PREFIX/lib -W
 
 # dependencies for building openresty
 OPENSSL_VERSION=${OPENSSL_VERSION:-"3.4.1"}
-OPENRESTY_VERSION="1.27.1.2"
-ngx_multi_upstream_module_ver="1.3.2"
+OPENRESTY_VERSION=${OPENRESTY_VERSION:-"1.29.2.4"}
+ngx_multi_upstream_module_ver="openresty-1.29.2-patches"
+ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit-"0081acfacb2e79b7a5aa4f1f455316dd343e145f"}
 mod_dubbo_ver="1.0.2"
-apisix_nginx_module_ver="1.19.4"
+apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
+# TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
+apisix_nginx_module_commit=${apisix_nginx_module_commit-"36c6de78d74dd0f093e9a25910875762f6f56da6"}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"
@@ -52,7 +55,7 @@ install_openssl_3(){
       --with-zlib-lib=$zlib_prefix/lib \
       --with-zlib-include=$zlib_prefix/include
     make -j $(nproc) LD_LIBRARY_PATH= CC="gcc"
-    sudo make install
+    sudo make install_sw install_ssldirs
     if [ -f "$OPENSSL_CONF_PATH" ]; then
         sudo cp "$OPENSSL_CONF_PATH" "$OPENSSL_PREFIX"/ssl/openssl.cnf
     fi
@@ -88,11 +91,23 @@ else
 fi
 
 if [ "$repo" == ngx_multi_upstream_module ]; then
+    ngx_multi_upstream_module_cloned=0
     cp -r "$prev_workdir" ./ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}
 else
-    git clone --depth=1 -b $ngx_multi_upstream_module_ver \
+    ngx_multi_upstream_module_cloned=1
+    ngx_multi_upstream_module_clone_ref="$ngx_multi_upstream_module_ver"
+    if [ -n "$ngx_multi_upstream_module_commit" ]; then
+        ngx_multi_upstream_module_clone_ref="master"
+    fi
+    git clone --depth=1 -b $ngx_multi_upstream_module_clone_ref \
         https://github.com/api7/ngx_multi_upstream_module.git \
         ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}
+fi
+if [ -n "$ngx_multi_upstream_module_commit" ] && [ "$ngx_multi_upstream_module_cloned" = 1 ]; then
+    git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} fetch --depth=1 \
+        origin "$ngx_multi_upstream_module_commit"
+    git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} checkout \
+        "$ngx_multi_upstream_module_commit"
 fi
 
 if [ "$repo" == mod_dubbo ]; then
@@ -104,11 +119,23 @@ else
 fi
 
 if [ "$repo" == apisix-nginx-module ]; then
+    apisix_nginx_module_cloned=0
     cp -r "$prev_workdir" ./apisix-nginx-module-${apisix_nginx_module_ver}
 else
-    git clone --depth=1 -b $apisix_nginx_module_ver \
+    apisix_nginx_module_cloned=1
+    apisix_nginx_module_clone_ref="$apisix_nginx_module_ver"
+    if [ -n "$apisix_nginx_module_commit" ]; then
+        apisix_nginx_module_clone_ref="main"
+    fi
+    git clone --depth=1 -b $apisix_nginx_module_clone_ref \
         https://github.com/api7/apisix-nginx-module.git \
         apisix-nginx-module-${apisix_nginx_module_ver}
+fi
+if [ -n "$apisix_nginx_module_commit" ] && [ "$apisix_nginx_module_cloned" = 1 ]; then
+    git -C apisix-nginx-module-${apisix_nginx_module_ver} fetch --depth=1 \
+        origin "$apisix_nginx_module_commit"
+    git -C apisix-nginx-module-${apisix_nginx_module_ver} checkout \
+        "$apisix_nginx_module_commit"
 fi
 
 if [ "$repo" == wasm-nginx-module ]; then

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -108,6 +108,12 @@ if [ -n "$ngx_multi_upstream_module_commit" ] && [ "$ngx_multi_upstream_module_c
         origin "$ngx_multi_upstream_module_commit"
     git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} checkout \
         "$ngx_multi_upstream_module_commit"
+elif [ -n "$ngx_multi_upstream_module_commit" ]; then
+    current_commit=$(git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} rev-parse HEAD)
+    if [ "$current_commit" != "$ngx_multi_upstream_module_commit" ]; then
+        echo "ERROR: ngx_multi_upstream_module HEAD ($current_commit) does not match pinned commit ($ngx_multi_upstream_module_commit)" >&2
+        exit 1
+    fi
 fi
 
 if [ "$repo" == mod_dubbo ]; then
@@ -136,6 +142,12 @@ if [ -n "$apisix_nginx_module_commit" ] && [ "$apisix_nginx_module_cloned" = 1 ]
         origin "$apisix_nginx_module_commit"
     git -C apisix-nginx-module-${apisix_nginx_module_ver} checkout \
         "$apisix_nginx_module_commit"
+elif [ -n "$apisix_nginx_module_commit" ]; then
+    current_commit=$(git -C apisix-nginx-module-${apisix_nginx_module_ver} rev-parse HEAD)
+    if [ "$current_commit" != "$apisix_nginx_module_commit" ]; then
+        echo "ERROR: apisix-nginx-module HEAD ($current_commit) does not match pinned commit ($apisix_nginx_module_commit)" >&2
+        exit 1
+    fi
 fi
 
 if [ "$repo" == wasm-nginx-module ]; then

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -66,6 +66,23 @@ install_openssl_3(){
     cd ..
 }
 
+verify_module_commit() {
+    local module_dir=$1
+    local expected_commit=$2
+    local current_commit
+
+    if ! git -C "$module_dir" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        echo "ERROR: $module_dir is not a git worktree; cannot verify pinned commit ($expected_commit)" >&2
+        exit 1
+    fi
+
+    current_commit=$(git -C "$module_dir" rev-parse HEAD)
+    if [ "$current_commit" != "$expected_commit" ]; then
+        echo "ERROR: $module_dir HEAD ($current_commit) does not match pinned commit ($expected_commit)" >&2
+        exit 1
+    fi
+}
+
 
 if ([ $# -gt 0 ] && [ "$1" == "latest" ]) || [ "$runtime_version" == "0.0.0" ]; then
     debug_args="--with-debug"
@@ -106,11 +123,8 @@ if [ -n "$ngx_multi_upstream_module_commit" ] && [ "$ngx_multi_upstream_module_c
     git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} checkout \
         "$ngx_multi_upstream_module_commit"
 elif [ -n "$ngx_multi_upstream_module_commit" ]; then
-    current_commit=$(git -C ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} rev-parse HEAD)
-    if [ "$current_commit" != "$ngx_multi_upstream_module_commit" ]; then
-        echo "ERROR: ngx_multi_upstream_module HEAD ($current_commit) does not match pinned commit ($ngx_multi_upstream_module_commit)" >&2
-        exit 1
-    fi
+    verify_module_commit "ngx_multi_upstream_module-${ngx_multi_upstream_module_ver}" \
+        "$ngx_multi_upstream_module_commit"
 fi
 
 if [ "$repo" == mod_dubbo ]; then
@@ -137,11 +151,8 @@ if [ -n "$apisix_nginx_module_commit" ] && [ "$apisix_nginx_module_cloned" = 1 ]
     git -C apisix-nginx-module-${apisix_nginx_module_ver} checkout \
         "$apisix_nginx_module_commit"
 elif [ -n "$apisix_nginx_module_commit" ]; then
-    current_commit=$(git -C apisix-nginx-module-${apisix_nginx_module_ver} rev-parse HEAD)
-    if [ "$current_commit" != "$apisix_nginx_module_commit" ]; then
-        echo "ERROR: apisix-nginx-module HEAD ($current_commit) does not match pinned commit ($apisix_nginx_module_commit)" >&2
-        exit 1
-    fi
+    verify_module_commit "apisix-nginx-module-${apisix_nginx_module_ver}" \
+        "$apisix_nginx_module_commit"
 fi
 
 if [ "$repo" == wasm-nginx-module ]; then

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -31,7 +31,7 @@ ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
-apisix_nginx_module_commit=${apisix_nginx_module_commit:-"f2d67049784fd9d035ba02cea5fcd55eee313f9d"}
+apisix_nginx_module_commit=${apisix_nginx_module_commit:-"c4b38ecbb54a47223112ba5d406f1dd392d44409"}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -30,6 +30,10 @@ ngx_multi_upstream_module_ver="openresty-1.29.2-patches"
 ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a400165fa40d21288e4eea8952bbf89"}
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
+if [[ ! "$apisix_nginx_module_ver" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+    echo "ERROR: invalid apisix_nginx_module_ver: $apisix_nginx_module_ver" >&2
+    exit 1
+fi
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
 apisix_nginx_module_commit=${apisix_nginx_module_commit:-"c4b38ecbb54a47223112ba5d406f1dd392d44409"}
 wasm_nginx_module_ver="0.7.0"
@@ -146,7 +150,7 @@ fi
 
 if [ "$repo" == apisix-nginx-module ]; then
     apisix_nginx_module_cloned=0
-    cp -r "$prev_workdir" ./apisix-nginx-module-${apisix_nginx_module_ver}
+    cp -r "$prev_workdir" "./apisix-nginx-module-${apisix_nginx_module_ver}"
 else
     apisix_nginx_module_cloned=1
     apisix_nginx_module_clone_ref="$apisix_nginx_module_ver"
@@ -155,9 +159,9 @@ else
         "apisix-nginx-module-${apisix_nginx_module_ver}"
 fi
 if [ -n "$apisix_nginx_module_commit" ] && [ "$apisix_nginx_module_cloned" = 1 ]; then
-    git -C apisix-nginx-module-${apisix_nginx_module_ver} fetch --depth=1 \
+    git -C "apisix-nginx-module-${apisix_nginx_module_ver}" fetch --depth=1 \
         origin "$apisix_nginx_module_commit"
-    git -C apisix-nginx-module-${apisix_nginx_module_ver} checkout \
+    git -C "apisix-nginx-module-${apisix_nginx_module_ver}" checkout \
         "$apisix_nginx_module_commit"
 elif [ -n "$apisix_nginx_module_commit" ]; then
     verify_module_commit "apisix-nginx-module-${apisix_nginx_module_ver}" \
@@ -184,7 +188,7 @@ cd ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} || exit 1
 ./patch.sh ../openresty-${OPENRESTY_VERSION}
 cd ..
 
-cd apisix-nginx-module-${apisix_nginx_module_ver}/patch || exit 1
+cd "apisix-nginx-module-${apisix_nginx_module_ver}/patch" || exit 1
 ./patch.sh ../../openresty-${OPENRESTY_VERSION}
 cd ../..
 
@@ -217,9 +221,9 @@ fi
     $debug_args \
     --add-module=../mod_dubbo-${mod_dubbo_ver} \
     --add-module=../ngx_multi_upstream_module-${ngx_multi_upstream_module_ver} \
-    --add-module=../apisix-nginx-module-${apisix_nginx_module_ver} \
-    --add-module=../apisix-nginx-module-${apisix_nginx_module_ver}/src/stream \
-    --add-module=../apisix-nginx-module-${apisix_nginx_module_ver}/src/meta \
+    --add-module="../apisix-nginx-module-${apisix_nginx_module_ver}" \
+    --add-module="../apisix-nginx-module-${apisix_nginx_module_ver}/src/stream" \
+    --add-module="../apisix-nginx-module-${apisix_nginx_module_ver}/src/meta" \
     --add-module=../wasm-nginx-module-${wasm_nginx_module_ver} \
     --add-module=../lua-var-nginx-module-${lua_var_nginx_module_ver} \
     --add-module=../lua-resty-events-${lua_resty_events_ver} \
@@ -265,7 +269,7 @@ sudo install -d "$OR_PREFIX"/lualib/resty/events/compat/
 sudo install -m 644 lualib/resty/events/compat/*.lua "$OR_PREFIX"/lualib/resty/events/compat/
 cd ..
 
-cd apisix-nginx-module-${apisix_nginx_module_ver} || exit 1
+cd "apisix-nginx-module-${apisix_nginx_module_ver}" || exit 1
 sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
 

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -81,6 +81,11 @@ verify_module_commit() {
         echo "ERROR: $module_dir HEAD ($current_commit) does not match pinned commit ($expected_commit)" >&2
         exit 1
     fi
+
+    if [ -n "$(git -C "$module_dir" status --porcelain --untracked-files=all)" ]; then
+        echo "ERROR: $module_dir has uncommitted changes; cannot verify pinned commit ($expected_commit)" >&2
+        exit 1
+    fi
 }
 
 
@@ -141,9 +146,9 @@ if [ "$repo" == apisix-nginx-module ]; then
 else
     apisix_nginx_module_cloned=1
     apisix_nginx_module_clone_ref="$apisix_nginx_module_ver"
-    git clone --depth=1 -b $apisix_nginx_module_clone_ref \
+    git clone --depth=1 -b "$apisix_nginx_module_clone_ref" -- \
         https://github.com/api7/apisix-nginx-module.git \
-        apisix-nginx-module-${apisix_nginx_module_ver}
+        "apisix-nginx-module-${apisix_nginx_module_ver}"
 fi
 if [ -n "$apisix_nginx_module_commit" ] && [ "$apisix_nginx_module_cloned" = 1 ]; then
     git -C apisix-nginx-module-${apisix_nginx_module_ver} fetch --depth=1 \

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -27,7 +27,7 @@ ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a
 mod_dubbo_ver="1.0.2"
 apisix_nginx_module_ver=${apisix_nginx_module_ver:-"openresty-1.29.2.4-patches"}
 # TODO: switch back to an apisix-nginx-module release tag after the 1.29.2.4 patches are released.
-apisix_nginx_module_commit=${apisix_nginx_module_commit:-"36c6de78d74dd0f093e9a25910875762f6f56da6"}
+apisix_nginx_module_commit=${apisix_nginx_module_commit:-"40492bca06153914d5084cfa92190c1dd7fd404e"}
 wasm_nginx_module_ver="0.7.0"
 lua_var_nginx_module_ver="v0.5.3"
 lua_resty_events_ver="0.2.0"

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -22,6 +22,10 @@ ld_opt=${ld_opt:-"-L$zlib_prefix/lib -L$pcre_prefix/lib -L$OPENSSL_PREFIX/lib -W
 # dependencies for building openresty
 OPENSSL_VERSION=${OPENSSL_VERSION:-"3.4.1"}
 OPENRESTY_VERSION=${OPENRESTY_VERSION:-"1.29.2.4"}
+if [[ ! "$OPENRESTY_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
+    echo "ERROR: invalid OPENRESTY_VERSION: $OPENRESTY_VERSION" >&2
+    exit 1
+fi
 ngx_multi_upstream_module_ver="openresty-1.29.2-patches"
 ngx_multi_upstream_module_commit=${ngx_multi_upstream_module_commit:-"125e594a1a400165fa40d21288e4eea8952bbf89"}
 mod_dubbo_ver="1.0.2"
@@ -101,8 +105,8 @@ cd "$workdir" || exit 1
 
 install_openssl_3
 
-wget --no-check-certificate https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz
-tar -zxvpf openresty-${OPENRESTY_VERSION}.tar.gz > /dev/null
+wget --no-check-certificate "https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz"
+tar -zxvpf "openresty-${OPENRESTY_VERSION}.tar.gz" > /dev/null
 
 if [ "$repo" == lua-resty-events ]; then
     cp -r "$prev_workdir" ./lua-resty-events-${lua_resty_events_ver}

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -19,10 +19,10 @@ install_apisix_dependencies_rpm() {
 install_dependencies_rpm() {
     # install basic dependencies
     if [[ $IMAGE_BASE == "registry.access.redhat.com/ubi9/ubi" ]]; then
-        yum install -y --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms wget tar gcc automake autoconf libtool make git which unzip sudo
+        yum install -y --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms wget tar gcc gcc-c++ automake autoconf libtool make git which unzip sudo
         yum install -y --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms yum-utils
     else
-        yum install -y wget tar gcc automake autoconf libtool make curl git which unzip sudo
+        yum install -y wget tar gcc gcc-c++ automake autoconf libtool make curl git which unzip sudo
         yum install -y yum-utils
     fi
 }


### PR DESCRIPTION
Upgrades the apisix-runtime build script to OpenResty 1.29.2.4 and OpenSSL 3.4.1.

The OpenResty patch module dependencies now use released tags:
- api7/ngx_multi_upstream_module `1.3.3`
- api7/apisix-nginx-module `1.19.5`

Validation:
- `git diff --check`
- `bash -n build-apisix-runtime.sh`
- verified both release tags resolve to the merged patch commits
- downstream APISIX validation PR: apache/apisix#13412