### PR TITLE
chore: stop packaging etcdctl in APISIX runtime

### DIFF
--- a/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-runtime-deb-ubuntu20.04.yml
@@ -41,7 +41,6 @@ jobs:
 
       - name: check and ensure apisix-runtime is installed
         run: |
-          docker exec ubuntu24.04Instance bash -c "/usr/local/openresty/bin/etcdctl -h" || exit 1
           export APISIX_RUNTIME_VER=$(docker exec ubuntu24.04Instance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_RUNTIME_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_RUNTIME_VER" != "${BUILD_APISIX_RUNTIME_VERSION}" ]; then exit 1; fi
 

--- a/.github/workflows/package-apisix-runtime-rpm-ubi.yml
+++ b/.github/workflows/package-apisix-runtime-rpm-ubi.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: check and ensure apisix-runtime is installed
         run: |
-          docker exec ubiInstance bash -c "/usr/local/openresty/bin/etcdctl -h" || exit 1
           export APISIX_RUNTIME_VER=$(docker exec ubiInstance bash -c "openresty -V" 2>&1 | awk '/-O2 -DAPISIX_RUNTIME_VER=/{print $5}' | awk -v FS="=" '{print $2}')
           if [ "$APISIX_RUNTIME_VER" != "${BUILD_APISIX_RUNTIME_VERSION}" ]; then exit 1; fi
 

--- a/build-apisix-base.sh
+++ b/build-apisix-base.sh
@@ -183,18 +183,3 @@ cd ..
 cd lua-resty-events-${lua_resty_events_ver} || exit 1
 sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
-
-# package etcdctl
-ETCD_ARCH="amd64"
-ETCD_VERSION=${ETCD_VERSION:-'3.5.4'}
-ARCH=${ARCH:-$(uname -m | tr '[:upper:]' '[:lower:]')}
-
-if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
-    ETCD_ARCH="arm64"
-fi
-
-wget -q https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz
-tar xf etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz
-# ship etcdctl under the same bin dir of openresty so we can package it easily
-sudo cp etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}/etcdctl "$OR_PREFIX"/bin/
-rm -rf etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}

--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -226,18 +226,3 @@ cd ..
 cd wasm-nginx-module-${wasm_nginx_module_ver} || exit 1
 sudo OPENRESTY_PREFIX="$OR_PREFIX" make install
 cd ..
-
-# package etcdctl
-ETCD_ARCH="amd64"
-ETCD_VERSION=${ETCD_VERSION:-'3.5.4'}
-ARCH=${ARCH:-$(uname -m | tr '[:upper:]' '[:lower:]')}
-
-if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
-    ETCD_ARCH="arm64"
-fi
-
-wget -q https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz
-tar xf etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}.tar.gz
-# ship etcdctl under the same bin dir of openresty so we can package it easily
-sudo cp etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}/etcdctl "$OR_PREFIX"/bin/
-rm -rf etcd-v${ETCD_VERSION}-linux-${ETCD_ARCH}


### PR DESCRIPTION
This removes `etcdctl` from the OpenResty distribution packages. It is not required by APISIX or OpenResty at runtime, and APISIX test environments install their own etcd client when needed.

Changes:
- stop downloading and copying `etcdctl` in `build-apisix-runtime.sh`
- stop downloading and copying `etcdctl` in `build-apisix-base.sh`
- remove runtime package CI checks that expected `/usr/local/openresty/bin/etcdctl` to exist

Validation:
- `rg -n "etcdctl|ETCD_VERSION|ETCD_ARCH|package etcdctl" build-apisix-runtime.sh build-apisix-base.sh .github/workflows`
- `bash -n build-apisix-runtime.sh build-apisix-base.sh package-apisix-runtime.sh package-apisix-base.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed etcdctl verification steps from CI/CD workflows for Ubuntu and UBI containers
  * Removed etcdctl download and installation from build scripts, streamlining the build process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/apisix-build-tools/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->