### PR TITLE
ci: add apisix-runtime release assets workflow

### DIFF
--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -38,6 +38,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y make ruby ruby-dev rubygems build-essential
 
+      - name: Validate version input
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "invalid version: $VERSION" >&2
+            exit 1
+          fi
+
       - name: Build apisix-runtime deb
         run: |
           make package type=deb app=apisix-runtime runtime_version="${VERSION}" image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }}
@@ -51,10 +58,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="apisix-runtime/${VERSION}"
-          if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --notes "Release apisix-runtime ${VERSION}" || \
-              gh release view "$tag" >/dev/null 2>&1
-          fi
+          gh release view "$tag" >/dev/null
           gh release upload "$tag" \
             "./output/apisix-runtime_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
             "./output/apisix-runtime-debug_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -7,6 +7,9 @@ on:
         description: "apisix-runtime version to release"
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release
@@ -26,7 +29,9 @@ jobs:
       VERSION: ${{ github.event.inputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -35,20 +40,20 @@ jobs:
 
       - name: Build apisix-runtime deb
         run: |
-          make package type=deb app=apisix-runtime runtime_version=${VERSION} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }}
+          make package type=deb app=apisix-runtime runtime_version="${VERSION}" image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }}
 
       - name: Build apisix-runtime-debug deb
         run: |
-          make package type=deb app=apisix-runtime runtime_version=${VERSION} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }} build_latest=latest artifact=apisix-runtime-debug
+          make package type=deb app=apisix-runtime runtime_version="${VERSION}" image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }} build_latest=latest artifact=apisix-runtime-debug
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: apisix-runtime/${{ env.VERSION }}
-          name: apisix-runtime/${{ env.VERSION }}
-          body: Release apisix-runtime ${{ env.VERSION }}
-          files: |
-            ./output/apisix-runtime_${{ env.VERSION }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
-            ./output/apisix-runtime-debug_${{ env.VERSION }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
-          fail_on_unmatched_files: true
-          overwrite_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="apisix-runtime/${VERSION}"
+          gh release view "$tag" >/dev/null 2>&1 || \
+            gh release create "$tag" --title "$tag" --notes "Release apisix-runtime ${VERSION}"
+          gh release upload "$tag" \
+            "./output/apisix-runtime_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
+            "./output/apisix-runtime-debug_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
+            --clobber

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -1,0 +1,54 @@
+name: Release apisix-runtime
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "apisix-runtime version to release"
+        required: true
+
+jobs:
+  release:
+    name: Release
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-22.04
+            arch: amd64
+            build_arch: linux/amd64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+            build_arch: linux/arm64/v8
+    runs-on: ${{ matrix.platform.runner }}
+    env:
+      VERSION: ${{ github.event.inputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make ruby ruby-dev rubygems build-essential
+
+      - name: Build apisix-runtime deb
+        run: |
+          make package type=deb app=apisix-runtime runtime_version=${VERSION} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }}
+
+      - name: Build apisix-runtime-debug deb
+        run: |
+          make package type=deb app=apisix-runtime runtime_version=${VERSION} image_base=debian image_tag=bookworm-slim arch=${{ matrix.platform.build_arch }} build_latest=latest artifact=apisix-runtime-debug
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: apisix-runtime/${{ env.VERSION }}
+          name: apisix-runtime/${{ env.VERSION }}
+          body: Release apisix-runtime ${{ env.VERSION }}
+          files: |
+            ./output/apisix-runtime_${{ env.VERSION }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
+            ./output/apisix-runtime-debug_${{ env.VERSION }}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb
+          fail_on_unmatched_files: true
+          overwrite_files: true

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -1,6 +1,9 @@
 name: Release apisix-runtime
 
 on:
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       version:
@@ -13,6 +16,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'apisix-runtime/')
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -25,8 +29,6 @@ jobs:
             arch: arm64
             build_arch: linux/arm64/v8
     runs-on: ${{ matrix.platform.runner }}
-    env:
-      VERSION: ${{ github.event.inputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -38,12 +40,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y make ruby ruby-dev rubygems build-essential
 
-      - name: Validate version input
+      - name: Resolve release version
+        env:
+          RAW_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}
         run: |
-          if [[ ! "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]]; then
-            echo "invalid version: $VERSION" >&2
+          version="${RAW_VERSION#apisix-runtime/}"
+          if [[ ! "$version" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "invalid version: $version" >&2
             exit 1
           fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=apisix-runtime/$version" >> "$GITHUB_ENV"
 
       - name: Build apisix-runtime deb
         run: |
@@ -57,9 +64,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="apisix-runtime/${VERSION}"
-          gh release view "$tag" >/dev/null
-          gh release upload "$tag" \
+          gh release view "$RELEASE_TAG" >/dev/null
+          gh release upload "$RELEASE_TAG" \
             "./output/apisix-runtime_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
             "./output/apisix-runtime-debug_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
             --clobber

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -18,11 +18,13 @@ jobs:
     name: Release
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'apisix-runtime/')
     timeout-minutes: 90
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || format('apisix-runtime/{0}', github.event.inputs.version) }}
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-24.04
             arch: amd64
             build_arch: linux/amd64
           - runner: ubuntu-24.04-arm
@@ -30,27 +32,25 @@ jobs:
             build_arch: linux/arm64/v8
     runs-on: ${{ matrix.platform.runner }}
     steps:
+      - name: Resolve release version
+        run: |
+          version="${RELEASE_TAG#apisix-runtime/}"
+          if [[ "$version" == "$RELEASE_TAG" || ! "$version" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y make ruby ruby-dev rubygems build-essential
-
-      - name: Resolve release version
-        env:
-          RAW_VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.version }}
-        run: |
-          version="${RAW_VERSION#apisix-runtime/}"
-          if [[ ! "$version" =~ ^[0-9A-Za-z._-]+$ ]]; then
-            echo "invalid version: $version" >&2
-            exit 1
-          fi
-          echo "VERSION=$version" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=apisix-runtime/$version" >> "$GITHUB_ENV"
 
       - name: Build apisix-runtime deb
         run: |

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -51,8 +51,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           tag="apisix-runtime/${VERSION}"
-          gh release view "$tag" >/dev/null 2>&1 || \
-            gh release create "$tag" --title "$tag" --notes "Release apisix-runtime ${VERSION}"
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" --title "$tag" --notes "Release apisix-runtime ${VERSION}" || \
+              gh release view "$tag" >/dev/null 2>&1
+          fi
           gh release upload "$tag" \
             "./output/apisix-runtime_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
             "./output/apisix-runtime-debug_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -21,7 +21,7 @@ jobs:
           - runner: ubuntu-22.04
             arch: amd64
             build_arch: linux/amd64
-          - runner: ubuntu-22.04-arm
+          - runner: ubuntu-24.04-arm
             arch: arm64
             build_arch: linux/arm64/v8
     runs-on: ${{ matrix.platform.runner }}

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ local_code_path=0
 openresty="apisix-runtime"
 artifact="0"
 runtime_version=0
+build_latest=
 apisix_repo="https://github.com/apache/apisix"
 apisix_runtime_repo="https://github.com/api7/apisix-build-tools.git"
 dashboard_repo="https://github.com/apache/apisix-dashboard"

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ define build_runtime
 		--build-arg RUNTIME_VERSION=$(runtime_version) \
 		--build-arg IMAGE_BASE=$(image_base) \
 		--build-arg IMAGE_TAG=$(image_tag) \
+		--build-arg BUILD_LATEST=$(build_latest) \
 		--build-arg CODE_PATH=$(4) \
     --platform $(arch) \
 		-f ./dockerfiles/Dockerfile.$(2).$(3) .
@@ -111,6 +112,7 @@ define build_runtime
 		--build-arg RUNTIME_VERSION=$(runtime_version) \
 		--build-arg IMAGE_BASE=$(image_base) \
 		--build-arg IMAGE_TAG=$(image_tag) \
+		--build-arg BUILD_LATEST=$(build_latest) \
 		--build-arg CODE_PATH=$(4) \
 		--load \
 		--cache-from=$(cache_from) \

--- a/package-apisix-runtime.sh
+++ b/package-apisix-runtime.sh
@@ -37,5 +37,5 @@ fi
 
 if [ "$PACKAGE_TYPE" == "deb" ]; then
     # Rename deb file with adding $DIST section
-    mv /output/apisix-runtime_"${RUNTIME_VERSION}"-"${ITERATION}"_"${PACKAGE_ARCH}".deb /output/apisix-runtime_"${RUNTIME_VERSION}"-"${ITERATION}"~"${dist}"_"${PACKAGE_ARCH}".deb
+    mv /output/"${artifact}"_"${RUNTIME_VERSION}"-"${ITERATION}"_"${PACKAGE_ARCH}".deb /output/"${artifact}"_"${RUNTIME_VERSION}"-"${ITERATION}"~"${dist}"_"${PACKAGE_ARCH}".deb
 fi


### PR DESCRIPTION
Add a release workflow for reusable apisix-runtime Debian assets.

The workflow now runs automatically when an `apisix-runtime/<version>` GitHub release is published, and still supports manual dispatch for reruns. It builds normal and debug Debian packages for amd64 and arm64 on Debian bookworm-slim, then uploads the resulting assets to the existing release.

This lets downstream images install prebuilt runtime packages from the release instead of rebuilding OpenResty during their own image builds.

Compatibility notes:
- only `apisix-runtime/*` releases run the job
- manual dispatch accepts the bare runtime version and uploads to `apisix-runtime/<version>`
- the release must already exist before assets are uploaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an on-demand release workflow to build and publish apisix-runtime Debian packages for amd64 and arm64 (manual or tagged release), producing normal and debug packages and uploading them to a GitHub Release.
  * Build process now supports a "latest" build flag.
  * Generated Debian package filenames consistently include the distribution suffix and dynamic versioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/api7/apisix-build-tools/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->