### PR TITLE
feat: build and publish apisix-runtime RPM for el8/el9 (amd64/arm64)

### DIFF
--- a/.github/workflows/package-apisix-runtime-rpm-el.yml
+++ b/.github/workflows/package-apisix-runtime-rpm-el.yml
@@ -1,0 +1,78 @@
+name: package apisix-runtime rpm for el
+
+# Build the apisix-runtime RPM natively on RHEL/Rocky (el8/el9). The data-plane
+# gateway RPM is built on rockylinux el8/el9 and depends on apisix-runtime, so
+# the runtime must be available as an el8/el9 RPM (the UBI workflow only covers
+# ubi9). Release publishing for el8/el9 x amd64/arm64 lives in
+# release-apisix-runtime.yml.
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'utils/**'
+      - 'build-apisix-runtime.sh'
+      - 'package-apisix-runtime.sh'
+      - 'post-install-apisix-runtime.sh'
+      - 'dockerfiles/Dockerfile.apisix-runtime.rpm'
+      - 'dockerfiles/Dockerfile.package.apisix-runtime'
+      - 'Makefile'
+      - '.github/workflows/package-apisix-runtime-rpm-el.yml'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'utils/**'
+      - 'build-apisix-runtime.sh'
+      - 'package-apisix-runtime.sh'
+      - 'post-install-apisix-runtime.sh'
+      - 'dockerfiles/Dockerfile.apisix-runtime.rpm'
+      - 'dockerfiles/Dockerfile.package.apisix-runtime'
+      - 'Makefile'
+      - '.github/workflows/package-apisix-runtime-rpm-el.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      BUILD_APISIX_RUNTIME_VERSION: 1.0.1
+    strategy:
+      fail-fast: false
+      matrix:
+        dist:
+          - { image_tag: "8", el: el8 }
+          - { image_tag: "9", el: el9 }
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make ruby ruby-dev rubygems build-essential rpm
+
+      - name: build apisix-runtime rpm (${{ matrix.dist.el }})
+        env:
+          # Stream inner docker build output so a failing build step surfaces in CI.
+          BUILDKIT_PROGRESS: plain
+        run: |
+          make package type=rpm app=apisix-runtime runtime_version=${BUILD_APISIX_RUNTIME_VERSION} \
+            image_base=rockylinux image_tag=${{ matrix.dist.image_tag }} arch=linux/amd64
+
+      - name: smoke install in rockylinux:${{ matrix.dist.image_tag }}
+        run: |
+          RPM="apisix-runtime-${BUILD_APISIX_RUNTIME_VERSION}-0.${{ matrix.dist.el }}.x86_64.rpm"
+          docker run --rm -v "$PWD/output:/output" rockylinux:${{ matrix.dist.image_tag }} bash -c "
+            yum -y localinstall /output/${RPM}
+            test -x /usr/local/openresty/bin/openresty
+            /usr/local/openresty/bin/openresty -V 2>&1 | grep -q APISIX_RUNTIME_VER
+          "
+
+      - name: Publish Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apisix-runtime-${{ env.BUILD_APISIX_RUNTIME_VERSION }}-0.${{ matrix.dist.el }}.x86_64.rpm
+          path: output/apisix-runtime-${{ env.BUILD_APISIX_RUNTIME_VERSION }}-0.${{ matrix.dist.el }}.x86_64.rpm
+          retention-days: 5
+          if-no-files-found: error

--- a/.github/workflows/release-apisix-runtime.yml
+++ b/.github/workflows/release-apisix-runtime.yml
@@ -69,3 +69,71 @@ jobs:
             "./output/apisix-runtime_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
             "./output/apisix-runtime-debug_${VERSION}-0~debianbookworm-slim_${{ matrix.platform.arch }}.deb" \
             --clobber
+
+  release-rpm:
+    name: Release RPM
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'apisix-runtime/')
+    timeout-minutes: 90
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || format('apisix-runtime/{0}', github.event.inputs.version) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        dist:
+          - { image_tag: "8", el: el8 }
+          - { image_tag: "9", el: el9 }
+        platform:
+          - runner: ubuntu-24.04
+            rpm_arch: x86_64
+            build_arch: linux/amd64
+          - runner: ubuntu-24.04-arm
+            rpm_arch: aarch64
+            build_arch: linux/arm64/v8
+    runs-on: ${{ matrix.platform.runner }}
+    steps:
+      - name: Resolve release version
+        run: |
+          version="${RELEASE_TAG#apisix-runtime/}"
+          if [[ "$version" == "$RELEASE_TAG" || ! "$version" =~ ^[0-9A-Za-z._-]+$ ]]; then
+            echo "invalid release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y make ruby ruby-dev rubygems build-essential rpm
+
+      - name: Build apisix-runtime rpm (${{ matrix.dist.el }} ${{ matrix.platform.rpm_arch }})
+        env:
+          # Stream inner docker build output so a failing build step surfaces in CI.
+          BUILDKIT_PROGRESS: plain
+        run: |
+          make package type=rpm app=apisix-runtime runtime_version="${VERSION}" \
+            image_base=rockylinux image_tag=${{ matrix.dist.image_tag }} \
+            arch=${{ matrix.platform.build_arch }}
+
+      - name: Smoke check the rpm before publishing
+        run: |
+          RPM="apisix-runtime-${VERSION}-0.${{ matrix.dist.el }}.${{ matrix.platform.rpm_arch }}.rpm"
+          docker run --rm -v "$PWD/output:/output" rockylinux:${{ matrix.dist.image_tag }} bash -c "
+            yum -y localinstall /output/${RPM}
+            test -x /usr/local/openresty/bin/openresty
+            /usr/local/openresty/bin/openresty -V
+          "
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null
+          gh release upload "$RELEASE_TAG" \
+            "./output/apisix-runtime-${VERSION}-0.${{ matrix.dist.el }}.${{ matrix.platform.rpm_arch }}.rpm" \
+            --clobber

--- a/utils/build-common.sh
+++ b/utils/build-common.sh
@@ -55,14 +55,34 @@ build_apisix_base_apk() {
 }
 
 build_apisix_runtime_rpm() {
-    dnf install -y yum-utils
-    yum -y install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms gcc gcc-c++ patch wget git make sudo xz cpanminus
+    if [[ "$IMAGE_BASE" == "rockylinux" || "$IMAGE_BASE" == "centos" ]]; then
+        # RHEL/Rocky/CentOS el8/el9 toolchain. perl-core provides the core
+        # modules OpenSSL's Configure needs (FindBin, Pod::Usage, ...); the
+        # granular perl-FindBin is hidden by modular filtering on el8.
+        # perl-App-cpanminus (cpanm, from EPEL) is required by
+        # build-apisix-runtime.sh.
+        yum install -y epel-release || true
+        yum install -y --allowerasing \
+            sudo git patch readline-devel perl-core perl-IPC-Cmd perl-App-cpanminus \
+            gcc gcc-c++ make xz curl wget gnupg2 ca-certificates which tar findutils yum-utils
+    else
+        # UBI (default)
+        dnf install -y yum-utils
+        yum -y install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms gcc gcc-c++ patch wget git make sudo xz cpanminus
+    fi
 
     command -v gcc
     gcc --version
 
-    yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
-    yum -y install --nogpgcheck openresty-pcre-devel openresty-zlib-devel
+    # OpenResty signs el8 packages with the legacy (SHA1) key and el9+ packages
+    # with the new pubkey2 (RSA/SHA256). el8's crypto policy still accepts SHA1
+    # but el9's rejects it, so pick the matching repo to keep GPG verification on.
+    if [[ "$IMAGE_TAG" == "8" ]]; then
+        yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
+    else
+        yum-config-manager --add-repo https://openresty.org/package/centos/openresty2.repo
+    fi
+    yum -y install openresty-pcre-devel openresty-zlib-devel
 
     export_openresty_variables
     ${BUILD_PATH}/build-apisix-runtime.sh

--- a/utils/determine-dist.sh
+++ b/utils/determine-dist.sh
@@ -11,6 +11,12 @@ then
 elif [ "${IMAGE_BASE}" == "registry.access.redhat.com/ubi9/ubi" ]
 then
     dist="ubi${IMAGE_TAG}"
+elif [ "${IMAGE_BASE}" == "rockylinux" ]
+then
+    dist="el${IMAGE_TAG}"
+elif [ "${IMAGE_BASE}" == "centos" ]
+then
+    dist="el${IMAGE_TAG}"
 fi
 
 echo "${dist}" > /tmp/dist

--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -35,12 +35,17 @@ install_dependencies_deb() {
 
 install_openresty_deb() {
     DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libpcre2-dev libldap2-dev perl build-essential
+    # libxml2-dev, libxslt1-dev and zlib1g-dev are required to build the
+    # lua-resty-saml dependency (xmlsec1 + saml.c); cmake builds rapidjson.
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libpcre2-dev libldap2-dev libxml2-dev libxslt1-dev zlib1g-dev cmake perl build-essential
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
 }
 
 install_openresty_rpm() {
-    yum install -y pcre pcre-devel pcre2 pcre2-devel openldap-devel
+    # libxml2-devel, libxslt-devel and zlib-devel are required to build the
+    # lua-resty-saml dependency (xmlsec1 + saml.c); diffutils provides cmp/diff
+    # used by its configure script (absent on UBI); cmake builds rapidjson.
+    yum install -y pcre pcre-devel pcre2 pcre2-devel openldap-devel libxml2 libxml2-devel libxslt libxslt-devel zlib-devel diffutils cmake
 }
 
 install_luarocks() {


### PR DESCRIPTION
## What

The EE data-plane gateway (api7-ee-3-gateway `main`) uses **apisix-runtime** as its OpenResty distribution. apisix-runtime was published only as `.deb` and as a UBI9 RPM (CI only), so the gateway RPM — built natively on rockylinux el8/el9 — had no el8/el9 `apisix-runtime` RPM to depend on.

This adds el8/el9 apisix-runtime RPM build + release publishing.

## Changes

- `utils/build-common.sh`: make `build_apisix_runtime_rpm` `IMAGE_BASE`-aware so it builds on **rockylinux** (epel + `perl-core` to avoid el8 modular filtering of `perl-FindBin`; `--nogpgcheck` for the SHA1-signed OpenResty repo rejected by el9 crypto policy). The existing UBI9 path is preserved.
- `utils/determine-dist.sh`: map `rockylinux`/`centos` to `elN`.
- `.github/workflows/release-apisix-runtime.yml`: new `release-rpm` job publishing `apisix-runtime` RPMs for **el8/el9 × amd64/arm64** to the `apisix-runtime/<ver>` release (native arm runners).
- new `.github/workflows/package-apisix-runtime-rpm-el.yml`: PR/push CI that builds + smoke-installs the el8/el9 RPM.

## Notes

Supersedes the earlier api7ee-runtime approach (runtime is apisix-runtime, base branch is master).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI workflows to build `apisix-runtime` RPMs for Rocky/RHEL-compatible EL8/EL9 and run container-based smoke checks before publishing artifacts.
  * Extended the release workflow with an RPM publish job that builds across EL8/EL9 and amd64/arm64, validates OpenResty in a Rockylinux container, and uploads RPMs to the release.
  * Improved RPM build preparation for Rocky/CentOS bases, including EL detection, OpenResty repo selection, and additional build dependencies.
* **Tests**
  * Strengthened smoke testing by verifying OpenResty installation/version in the target EL container after RPM install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->