### PR TITLE
fix: install libxml2 dev headers to build xmlsec1

### DIFF
--- a/utils/install-common.sh
+++ b/utils/install-common.sh
@@ -35,12 +35,15 @@ install_dependencies_deb() {
 
 install_openresty_deb() {
     DEBIAN_FRONTEND=noninteractive apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libpcre2-dev libldap2-dev perl build-essential
+    # libxml2-dev is required to build xmlsec1 (a lua-resty-saml dependency).
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libreadline-dev lsb-release libpcre3 libpcre3-dev libpcre2-dev libldap2-dev libxml2-dev perl build-essential
     DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends wget gnupg ca-certificates
 }
 
 install_openresty_rpm() {
-    yum install -y pcre pcre-devel pcre2 pcre2-devel openldap-devel
+    # libxml2-devel is required to build xmlsec1 (a lua-resty-saml dependency);
+    # diffutils provides cmp/diff used by its configure script (absent on UBI).
+    yum install -y pcre pcre-devel pcre2 pcre2-devel openldap-devel libxml2 libxml2-devel diffutils
 }
 
 install_luarocks() {


### PR DESCRIPTION
## Problem

Both `package apisix deb for ubuntu 24.04` and `package apisix rpm for ubi` fail at the same step while building APISIX:

```
configure: error: libxml2 library >= 2.8.0 is required for this version of xmlsec1
Error: Failed installing dependency: lua-resty-saml-0.2.5-0.src.rock - Build error
```

APISIX depends on `lua-resty-saml`, which compiles `xmlsec1` from source. Its `./configure` needs the **libxml2 >= 2.8.0 dev headers** (and `cmp`/`diff` from diffutils, which are absent on UBI). `install-common.sh` installs pcre/pcre2/openldap dev libs but not libxml2, so both the deb and rpm app builds break.

## Fix

- `install_openresty_deb`: add `libxml2-dev`.
- `install_openresty_rpm`: add `libxml2 libxml2-devel diffutils`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies for improved system compatibility and installation stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->