### PR TITLE
ci: use local httpbin upstream in deb smoke test

### DIFF
--- a/.github/workflows/package-apisix-deb-ubuntu20.04.yml
+++ b/.github/workflows/package-apisix-deb-ubuntu20.04.yml
@@ -41,7 +41,11 @@ jobs:
 
       - name: start apisix and test
         run: |
-          docker run -d --name apisix-${PACKAGE_APISIX_VERSION}-deb-test -v $(pwd)/test/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 9443:9443 apache/apisix:${PACKAGE_APISIX_VERSION}-deb-test
+          # local httpbin upstream so the smoke test never depends on the public httpbin.org
+          docker network create apisix-deb-test-net
+          docker run -d --name httpbin --network apisix-deb-test-net kennethreitz/httpbin
+
+          docker run -d --name apisix-${PACKAGE_APISIX_VERSION}-deb-test --network apisix-deb-test-net -v $(pwd)/test/apisix/config.yaml:/usr/local/apisix/conf/config.yaml -p 9180:9180 -p 9080:9080 -p 9443:9443 apache/apisix:${PACKAGE_APISIX_VERSION}-deb-test
           sleep 20
 
           docker ps -a
@@ -54,7 +58,7 @@ jobs:
               "upstream": {
                   "type": "roundrobin",
                   "nodes": {
-                      "httpbin.org:80": 1
+                      "httpbin:80": 1
                   }
               }
             }'


### PR DESCRIPTION
## What

The `package apisix deb for ubuntu 24.04` smoke test creates a route whose upstream points at the public `httpbin.org`, then curls `/get` through it. When `httpbin.org` is slow or unreachable the curl times out (exit 28) and the job fails, even though the package built and APISIX started fine.

## Change

Run a local `kennethreitz/httpbin` container on a dedicated docker network, attach the APISIX test container to the same network, and point the route upstream at `httpbin:80` instead of `httpbin.org:80`. The smoke test no longer depends on external network reachability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Ubuntu 20.04 deb package smoke tests to use local services instead of external dependencies, improving test reliability and independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->