### PR TITLE
chore: bump apisix-nginx-module to 1.19.6

### DIFF
--- a/build-apisix-runtime.sh
+++ b/build-apisix-runtime.sh
@@ -28,7 +28,7 @@ if [[ ! "$OPENRESTY_VERSION" =~ ^[0-9]+(\.[0-9]+)+$ ]]; then
 fi
 ngx_multi_upstream_module_ver="1.3.3"
 mod_dubbo_ver="1.0.2"
-apisix_nginx_module_ver=${apisix_nginx_module_ver:-"1.19.5"}
+apisix_nginx_module_ver=${apisix_nginx_module_ver:-"1.19.6"}
 if [[ ! "$apisix_nginx_module_ver" =~ ^[A-Za-z0-9._/-]+$ ]]; then
     echo "ERROR: invalid apisix_nginx_module_ver: $apisix_nginx_module_ver" >&2
     exit 1


### PR DESCRIPTION
Bump `apisix_nginx_module_ver` from 1.19.5 to 1.19.6 in `build-apisix-runtime.sh`.

Release: https://github.com/api7/apisix-nginx-module/releases/tag/1.19.6
- support upstream mTLS client cert via C-API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled runtime component to a newer version, which may improve compatibility and stability during application startup and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->