### PR TITLE
fix: declare libxml2 and libxslt deps for saml-auth plugin

### DIFF
--- a/package-apisix.sh
+++ b/package-apisix.sh
@@ -25,6 +25,13 @@ if [ "$PACKAGE_TYPE" == "deb" ]
 then
 	dep_which="debianutils"
 fi
+# saml-auth plugin's saml.so links libxml2 and libxslt
+dep_libxml2="libxml2"
+dep_libxslt="libxslt"
+if [ "$PACKAGE_TYPE" == "deb" ]
+then
+	dep_libxslt="libxslt1.1"
+fi
 
 # Determine the min version of openresty or apisix-base
 if [ "$OPENRESTY" == "apisix-base" ]
@@ -62,6 +69,8 @@ then
         -d "$dep_pcre" \
         -d "$dep_which" \
         -d "$dep_libyaml" \
+        -d "$dep_libxml2" \
+        -d "$dep_libxslt" \
         --post-install post-install-apisix-runtime.sh \
         --description 'Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.' \
         --license "ASL 2.0" \
@@ -83,6 +92,8 @@ else
         -d "$dep_ldap" \
         -d "$dep_pcre" \
         -d "$dep_which" \
+        -d "$dep_libxml2" \
+        -d "$dep_libxslt" \
         --description 'Apache APISIX is a distributed gateway for APIs and Microservices, focused on high performance and reliability.' \
         --license "ASL 2.0" \
         -C /tmp/build/output/apisix \

--- a/test/apisix/Dockerfile.test.apisix.arm64.ubuntu24.04
+++ b/test/apisix/Dockerfile.test.apisix.arm64.ubuntu24.04
@@ -25,7 +25,7 @@ RUN set -x \
 # install apisix
 RUN set -x \
     && /install-common.sh install_etcd \
-    && apt install -y libldap2-dev libyaml-dev \
+    && apt install -y libldap2-dev libyaml-dev libxml2 libxslt1.1 \
     && dpkg -i /apisix_${APISIX_VERSION}-0~${IMAGE_BASE}${IMAGE_TAG}_arm64.deb
 
 # start etcd and test

--- a/test/apisix/Dockerfile.test.apisix.deb.ubuntu24.04
+++ b/test/apisix/Dockerfile.test.apisix.deb.ubuntu24.04
@@ -29,7 +29,7 @@ RUN /install-common.sh install_etcd
 
 # install apisix
 RUN set -x \
-    && apt install -y libldap2-dev libyaml-dev \
+    && apt install -y libldap2-dev libyaml-dev libxml2 libxslt1.1 \
     && dpkg -i /apisix_${APISIX_VERSION}-0~${IMAGE_BASE}${IMAGE_TAG}_amd64.deb
 
 # start etcd and test


### PR DESCRIPTION
### Problem

APISIX 3.17.0 added the `saml-auth` plugin (apache/apisix#13346), which bundles the `lua-resty-saml` rock. Its native `saml.so` dynamically links `libxml2.so.2` and `libxslt.so.1`, but the `apisix` package never declared those libraries as dependencies. A clean install (e.g. the official docker images) is therefore missing them, and every worker fails to load the plugin on startup:

```
[error] load_plugin(): failed to load plugin [saml-auth] err: error loading module 'saml'
from '/usr/local/apisix/deps/lib/lua/5.1/saml.so': libxml2.so.2: cannot open shared object file
```

```
$ ldd /usr/local/apisix/deps/lib/lua/5.1/saml.so
  libxml2.so.2 => not found
  libxslt.so.1 => not found
```

### Fix

Add `libxml2` + `libxslt` to the fpm `--depends` list for both package variants (`libxslt1.1` is the deb package name; `libxslt` the rpm one; `libxml2` is the same on both). Package names verified to resolve on debian bookworm / ubuntu noble and on UBI9 (`libxslt` provides `libxslt.so.1` from appstream).

This is the upstream packaging counterpart to the docker-side mitigation in apache/apisix-docker#627, which installs the libs directly in the image. With the dependency declared here, the image no longer needs to special-case it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build/test images to install additional XML/XSLT system libraries.
  * Ensured packaging metadata includes the extra library dependencies so generated Debian/RPM packages declare them consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->